### PR TITLE
Refine session cookie helper for environment-specific options

### DIFF
--- a/backend/src/utils/session-cookie.js
+++ b/backend/src/utils/session-cookie.js
@@ -1,11 +1,20 @@
 const config = require('../config');
 
+const productionCookieOptions = {
+  secure: true,
+  sameSite: 'none',
+};
+
+const nonProductionCookieOptions = {
+  secure: false,
+  sameSite: 'lax',
+};
+
 const getSessionCookieBaseOptions = () => ({
   httpOnly: true,
-  secure: config.isProduction,
-  sameSite: config.isProduction ? 'none' : 'lax',
   signed: true,
   path: '/',
+  ...(config.isProduction ? productionCookieOptions : nonProductionCookieOptions),
 });
 
 const getSessionCookieOptions = (expiresAt) => ({


### PR DESCRIPTION
## Summary
- clarify the session cookie helper to centralize environment-specific options
- ensure production cookies are marked secure with `sameSite: 'none'` and dev/test cookies remain lax

## Testing
- npm test -- --runInBand *(fails: Cannot find module '@sentry/node')*

------
https://chatgpt.com/codex/tasks/task_e_68cdfe01c2688325b97c00c16f68306b