### PR TITLE
Ensure protected queries only run when authenticated

### DIFF
--- a/frontend/src/features/allowlist/hooks/useAllowlist.ts
+++ b/frontend/src/features/allowlist/hooks/useAllowlist.ts
@@ -9,11 +9,17 @@ import {
 } from '../api/allowlist';
 import type { AllowedRole, AllowlistEntry } from '../types/allowlist';
 import { HttpError } from '@/lib/api/http';
+import { useAuth } from '@/features/auth/hooks/useAuth';
 
 export const useAllowlist = () => {
+  const { status, user } = useAuth();
+  const isAuthenticated = status === 'authenticated';
+  const isAdmin = user?.role === 'admin';
+
   return useQuery({
     queryKey: ALLOWLIST_QUERY_KEY,
     queryFn: fetchAllowlist,
+    enabled: isAuthenticated && isAdmin,
   });
 };
 

--- a/frontend/src/features/auth/context/AuthContext.tsx
+++ b/frontend/src/features/auth/context/AuthContext.tsx
@@ -1,4 +1,4 @@
-﻿/* eslint-disable react-refresh/only-export-components */
+/* eslint-disable react-refresh/only-export-components */
 import React, { createContext, useCallback, useEffect, useMemo, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 
@@ -10,7 +10,7 @@ import {
   type AuthSession,
 } from '../api/auth';
 import { ALLOWLIST_QUERY_KEY } from '@/features/allowlist/api/allowlist';
-import { HELLO_QUERY_KEY } from '@/features/hello/hooks/useHelloMessage';
+import { HELLO_QUERY_KEY } from '@/features/hello/hooks/constants';
 import { onUnauthorized } from '@/lib/api/http';
 
 const GUEST_SESSION: AuthSession = { authenticated: false, user: null };

--- a/frontend/src/features/hello/components/HelloMessageCard.tsx
+++ b/frontend/src/features/hello/components/HelloMessageCard.tsx
@@ -20,7 +20,7 @@ export const HelloMessageCard = () => {
   const { status } = useAuth();
   const isAuthenticated = status === 'authenticated';
   const isCheckingSession = status === 'unknown';
-  const { data, isLoading, isError, refetch, isRefetching } = useHelloMessage({ enabled: isAuthenticated });
+  const { data, isLoading, isError, refetch, isRefetching } = useHelloMessage();
 
   const handleRefetch = () => {
     refetch().catch((error) => {

--- a/frontend/src/features/hello/hooks/constants.ts
+++ b/frontend/src/features/hello/hooks/constants.ts
@@ -1,0 +1,1 @@
+export const HELLO_QUERY_KEY = ['hello'] as const;

--- a/frontend/src/features/hello/hooks/useHelloMessage.ts
+++ b/frontend/src/features/hello/hooks/useHelloMessage.ts
@@ -1,18 +1,18 @@
-﻿import { useQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 
 import { getHelloMessage } from '../api/hello';
 import type { HelloMessage } from '../types/hello';
+import { useAuth } from '@/features/auth/hooks/useAuth';
 
-export const HELLO_QUERY_KEY = ['hello'] as const;
+import { HELLO_QUERY_KEY } from './constants';
 
-export type UseHelloMessageOptions = {
-  enabled?: boolean;
-};
+export const useHelloMessage = () => {
+  const { status } = useAuth();
+  const isAuthenticated = status === 'authenticated';
 
-export const useHelloMessage = (options?: UseHelloMessageOptions) => {
   return useQuery<HelloMessage>({
     queryKey: HELLO_QUERY_KEY,
     queryFn: getHelloMessage,
-    enabled: options?.enabled ?? true,
+    enabled: isAuthenticated,
   });
 };


### PR DESCRIPTION
## Summary
- gate the hello message query by deriving authentication status inside the hook and share its query key constant
- prevent the allowlist query from firing until an authenticated admin is present

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cdfe1bb22883259168f11b36e14fd5