### PR TITLE
Persist selected language preference

### DIFF
--- a/frontend/src/components/navigation/LanguageSwitcher.tsx
+++ b/frontend/src/components/navigation/LanguageSwitcher.tsx
@@ -1,19 +1,41 @@
-﻿import { ChangeEvent } from 'react';
+import { ChangeEvent, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 const SUPPORTED_LOCALES = [
-  { value: 'pt-BR', label: '\u{1F1E7}\u{1F1F7} Portugu\u00EAs' },
+  { value: 'pt-BR', label: '\u{1F1E7}\u{1F1F7} Português' },
   { value: 'en', label: '\u{1F1FA}\u{1F1F8} English' },
 ];
+
+const LANGUAGE_STORAGE_KEY = 'lkdposts-language';
 
 export const LanguageSwitcher = () => {
   const { i18n } = useTranslation();
 
   const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
-    i18n.changeLanguage(event.target.value).catch((err) => {
+    const nextLanguage = event.target.value;
+
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(LANGUAGE_STORAGE_KEY, nextLanguage);
+    }
+
+    i18n.changeLanguage(nextLanguage).catch((err) => {
       console.error('Failed to change language', err);
     });
   };
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const storedLanguage = window.localStorage.getItem(LANGUAGE_STORAGE_KEY);
+
+    if (storedLanguage && storedLanguage !== i18n.language) {
+      i18n.changeLanguage(storedLanguage).catch((err) => {
+        console.error('Failed to load stored language', err);
+      });
+    }
+  }, [i18n]);
 
   return (
     <label className="flex items-center gap-2 text-sm font-medium text-muted-foreground">

--- a/frontend/src/config/i18n.ts
+++ b/frontend/src/config/i18n.ts
@@ -198,6 +198,7 @@ i18n
     detection: {
       order: ['querystring', 'localStorage', 'navigator'],
       caches: ['localStorage'],
+      lookupLocalStorage: 'lkdposts-language',
     },
   })
   .catch((error) => {


### PR DESCRIPTION
## Summary
- persist the selected language in localStorage when the user changes it
- reload the saved language on mount so the selector reflects the last choice
- configure the i18n detector to read and store the language under the custom key

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0118cdba48325ad74d79c89b7b61e