### PR TITLE
Fix Vercel routing config and resolve lint issues

### DIFF
--- a/api/[...slug].js
+++ b/api/[...slug].js
@@ -1,0 +1,1 @@
+module.exports = require("../backend/src/vercel");

--- a/frontend/src/features/auth/components/GoogleLoginButton.tsx
+++ b/frontend/src/features/auth/components/GoogleLoginButton.tsx
@@ -58,8 +58,8 @@ export const GoogleLoginButton: React.FC = () => {
 
       google.accounts.id.initialize({
         client_id: ENV.GOOGLE_CLIENT_ID,
-        callback: async (response: CredentialResponse) => {
-          await handleCredential(response);
+        callback: (response: CredentialResponse) => {
+          void handleCredential(response);
         },
         ux_mode: 'popup',
       });

--- a/frontend/src/lib/api/http.ts
+++ b/frontend/src/lib/api/http.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { type AxiosResponse } from 'axios';
 import { ENV } from '@/config/env';
 import { z, type ZodType, type ZodTypeDef } from 'zod';
 
@@ -125,13 +125,17 @@ apiHttpClient.interceptors.response.use(
   (response) => response,
   (error) => {
     if (axios.isAxiosError(error) && error.response) {
-      const { status, statusText, data } = error.response;
+      const response: AxiosResponse<unknown> = error.response;
+      const { status, statusText, data } = response;
       const fallback = statusText || DEFAULT_ERROR_MESSAGE;
       const message = extractErrorMessage(data, fallback);
       return Promise.reject(createHttpError(message, status, data));
     }
 
-    return Promise.reject(error);
+    const fallbackMessage = error instanceof Error ? error.message : DEFAULT_ERROR_MESSAGE;
+    const fallbackError = error instanceof Error ? error : new Error(fallbackMessage);
+
+    return Promise.reject(fallbackError);
   },
 );
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import * as Sentry from '@sentry/react';

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/consistent-type-definitions, @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
 /// <reference types="vite/client" />
 
 declare global {

--- a/vercel.json
+++ b/vercel.json
@@ -4,12 +4,6 @@
       "runtime": "nodejs20.x"
     }
   },
-  "routes": [
-    {
-      "src": "/api/(.*)",
-      "dest": "/api/index.js"
-    }
-  ],
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary
- remove the legacy routes entry from Vercel config and add a catch-all serverless function so the backend API keeps working alongside global headers
- fix the Google login button callback to avoid returning a Promise to a void handler and clean up redundant lint disables
- tighten the HTTP client interceptor to avoid unsafe destructuring and always reject with Error instances

## Testing
- npm run lint (backend)
- npm run lint (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68d01669b1488325b662fe2b9b6c855a