### PR TITLE
feat(prisma): add feed article post models

### DIFF
--- a/backend/prisma/migrations/20250220120000_feed_articles_posts/migration.sql
+++ b/backend/prisma/migrations/20250220120000_feed_articles_posts/migration.sql
@@ -1,0 +1,56 @@
+-- CreateTable
+CREATE TABLE "public"."Feed" (
+    "id" SERIAL NOT NULL,
+    "ownerKey" VARCHAR(255) NOT NULL,
+    "url" TEXT NOT NULL,
+    "title" TEXT,
+    "lastFetchedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Feed_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Article" (
+    "id" SERIAL NOT NULL,
+    "feedId" INTEGER NOT NULL,
+    "title" TEXT NOT NULL,
+    "contentSnippet" TEXT NOT NULL,
+    "publishedAt" TIMESTAMP(3) NOT NULL,
+    "guid" TEXT,
+    "link" TEXT,
+    "dedupeKey" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Article_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Post" (
+    "id" SERIAL NOT NULL,
+    "articleId" INTEGER NOT NULL,
+    "content" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Post_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "public"."Article" ADD CONSTRAINT "Article_feedId_fkey" FOREIGN KEY ("feedId") REFERENCES "public"."Feed"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Post" ADD CONSTRAINT "Post_articleId_fkey" FOREIGN KEY ("articleId") REFERENCES "public"."Article"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Feed_ownerKey_url_key" ON "public"."Feed"("ownerKey", "url");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Article_feedId_guid_key" ON "public"."Article"("feedId", "guid");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Article_feedId_link_key" ON "public"."Article"("feedId", "link");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Article_feedId_dedupeKey_key" ON "public"."Article"("feedId", "dedupeKey");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Post_articleId_key" ON "public"."Post"("articleId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -41,3 +41,43 @@ model UserSession {
   ipAddress   String?     @db.VarChar(45)
 }
 
+model Feed {
+  id           Int       @id @default(autoincrement())
+  ownerKey     String    @db.VarChar(255)
+  url          String    @db.Text
+  title        String?   @db.Text
+  lastFetchedAt DateTime?
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
+  articles     Article[]
+
+  @@unique([ownerKey, url])
+}
+
+model Article {
+  id             Int       @id @default(autoincrement())
+  feedId         Int
+  feed           Feed      @relation(fields: [feedId], references: [id], onDelete: Cascade)
+  title          String    @db.Text
+  contentSnippet String    @db.Text
+  publishedAt    DateTime
+  guid           String?   @db.Text
+  link           String?   @db.Text
+  dedupeKey      String    @db.Text
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+  post           Post?
+
+  @@unique([feedId, guid])
+  @@unique([feedId, link])
+  @@unique([feedId, dedupeKey])
+}
+
+model Post {
+  id        Int      @id @default(autoincrement())
+  articleId Int      @unique
+  article   Article  @relation(fields: [articleId], references: [id], onDelete: Cascade)
+  content   String   @db.Text
+  createdAt DateTime @default(now())
+}
+


### PR DESCRIPTION
## Summary
- add Prisma models for Feed, Article, and Post with ownership, lifecycle fields, and required relations
- enforce uniqueness across feeds and articles plus cascading deletion from articles to posts via SQL migration

## Testing
- npm run db:generate

------
https://chatgpt.com/codex/tasks/task_e_68d01ffae98c8325ac75a1cc297f1422