### PR TITLE
feat: add authenticated feed management API

### DIFF
--- a/backend/src/controllers/feed.controller.js
+++ b/backend/src/controllers/feed.controller.js
@@ -1,0 +1,120 @@
+const asyncHandler = require('../utils/async-handler');
+const ApiError = require('../utils/api-error');
+const feedService = require('../services/feed.service');
+
+const parsePositiveInteger = (value, { field = 'id', required = false } = {}) => {
+  if (value === undefined || value === null || value === '') {
+    if (required) {
+      throw new ApiError({ statusCode: 400, code: 'INVALID_INPUT', message: `Invalid ${field}` });
+    }
+
+    return null;
+  }
+
+  const number = Number(value);
+
+  if (!Number.isInteger(number) || number <= 0) {
+    throw new ApiError({ statusCode: 400, code: 'INVALID_INPUT', message: `Invalid ${field}` });
+  }
+
+  return number;
+};
+
+const getOwnerKey = (req) => {
+  if (!req.user || req.user.id == null) {
+    throw new ApiError({ statusCode: 401, code: 'UNAUTHENTICATED', message: 'Authentication required' });
+  }
+
+  return String(req.user.id);
+};
+
+const mapFeed = (feed) => ({
+  id: feed.id,
+  url: feed.url,
+  title: feed.title ?? null,
+  lastFetchedAt: feed.lastFetchedAt ?? null,
+  createdAt: feed.createdAt,
+  updatedAt: feed.updatedAt,
+});
+
+const list = asyncHandler(async (req, res) => {
+  const ownerKey = getOwnerKey(req);
+  const cursor = req.query.cursor != null ? parsePositiveInteger(req.query.cursor, { field: 'cursor' }) : null;
+  const limit = req.query.limit != null ? parsePositiveInteger(req.query.limit, { field: 'limit' }) : undefined;
+
+  const { items, nextCursor, total, limit: appliedLimit } = await feedService.listFeeds({ ownerKey, cursor, limit });
+
+  return res.success(
+    {
+      items: items.map(mapFeed),
+    },
+    {
+      meta: {
+        nextCursor: nextCursor != null ? String(nextCursor) : null,
+        total,
+        limit: appliedLimit,
+      },
+    }
+  );
+});
+
+const create = asyncHandler(async (req, res) => {
+  const ownerKey = getOwnerKey(req);
+  const { url, title } = req.body ?? {};
+
+  if (url == null) {
+    throw new ApiError({ statusCode: 400, code: 'URL_REQUIRED', message: 'URL is required' });
+  }
+
+  const feed = await feedService.createFeed({ ownerKey, url, title });
+
+  return res.success(mapFeed(feed), { statusCode: 201 });
+});
+
+const bulkCreate = asyncHandler(async (req, res) => {
+  const ownerKey = getOwnerKey(req);
+  const { urls } = req.body ?? {};
+
+  const result = await feedService.createFeedsInBulk({ ownerKey, urls });
+
+  return res.success({
+    created: result.created.map(mapFeed),
+    duplicates: result.duplicates.map((entry) => ({
+      url: entry.url,
+      reason: entry.reason,
+      feedId: entry.feedId ?? null,
+    })),
+    invalid: result.invalid.map((entry) => ({ url: entry.url, reason: entry.reason })),
+  });
+});
+
+const update = asyncHandler(async (req, res) => {
+  const ownerKey = getOwnerKey(req);
+  const feedId = parsePositiveInteger(req.params.id, { field: 'id', required: true });
+  const { title, url } = req.body ?? {};
+
+  if (title === undefined && url === undefined) {
+    throw new ApiError({ statusCode: 400, code: 'NO_UPDATES_PROVIDED', message: 'No updates provided' });
+  }
+
+  const feed = await feedService.updateFeed({ ownerKey, feedId, title, url });
+
+  return res.success(mapFeed(feed));
+});
+
+const remove = asyncHandler(async (req, res) => {
+  const ownerKey = getOwnerKey(req);
+  const feedId = parsePositiveInteger(req.params.id, { field: 'id', required: true });
+
+  await feedService.deleteFeed({ ownerKey, feedId });
+
+  return res.success({ message: 'Feed removed' });
+});
+
+module.exports = {
+  list,
+  create,
+  bulkCreate,
+  update,
+  remove,
+};

--- a/backend/src/docs/openapi.js
+++ b/backend/src/docs/openapi.js
@@ -50,6 +50,47 @@ const definition = {
           },
         },
       },
+      Feed: {
+        type: 'object',
+        properties: {
+          id: { type: 'integer', example: 1 },
+          url: { type: 'string', format: 'uri', example: 'https://example.com/rss.xml' },
+          title: { type: ['string', 'null'], example: 'My RSS feed' },
+          lastFetchedAt: { type: ['string', 'null'], format: 'date-time', example: null },
+          createdAt: { type: 'string', format: 'date-time', example: '2025-01-20T12:34:56.000Z' },
+          updatedAt: { type: 'string', format: 'date-time', example: '2025-01-20T12:34:56.000Z' },
+        },
+      },
+      FeedBulkResult: {
+        type: 'object',
+        properties: {
+          created: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/Feed' },
+          },
+          duplicates: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                url: { type: 'string', format: 'uri' },
+                reason: { type: 'string', example: 'ALREADY_EXISTS' },
+                feedId: { type: ['integer', 'null'], example: 1 },
+              },
+            },
+          },
+          invalid: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                url: { type: 'string' },
+                reason: { type: 'string', example: 'INVALID_URL' },
+              },
+            },
+          },
+        },
+      },
     },
   },
 };

--- a/backend/src/routes/v1/feed.routes.js
+++ b/backend/src/routes/v1/feed.routes.js
@@ -1,0 +1,191 @@
+const express = require('express');
+const feedController = require('../../controllers/feed.controller');
+
+const router = express.Router();
+
+/**
+ * @openapi
+ * /api/v1/feeds:
+ *   get:
+ *     summary: List RSS feeds owned by the authenticated user
+ *     tags:
+ *       - Feeds
+ *     parameters:
+ *       - in: query
+ *         name: cursor
+ *         schema:
+ *           type: string
+ *           description: Cursor pointing to the last feed received in the previous page
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 50
+ *         description: Maximum number of feeds to return per request
+ *     responses:
+ *       '200':
+ *         description: Paginated list of feeds
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Envelope'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       type: object
+ *                       properties:
+ *                         items:
+ *                           type: array
+ *                           items:
+ *                             $ref: '#/components/schemas/Feed'
+ *                     meta:
+ *                       type: object
+ *                       properties:
+ *                         nextCursor:
+ *                           type: string
+ *                           nullable: true
+ *                         total:
+ *                           type: integer
+ *                         limit:
+ *                           type: integer
+ *   post:
+ *     summary: Create a new RSS feed for the authenticated user
+ *     tags:
+ *       - Feeds
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - url
+ *             properties:
+ *               url:
+ *                 type: string
+ *                 format: uri
+ *               title:
+ *                 type: string
+ *                 nullable: true
+ *     responses:
+ *       '201':
+ *         description: Feed created successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Envelope'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       $ref: '#/components/schemas/Feed'
+ */
+router.get('/feeds', feedController.list);
+router.post('/feeds', feedController.create);
+
+/**
+ * @openapi
+ * /api/v1/feeds/bulk:
+ *   post:
+ *     summary: Create multiple RSS feeds in a single request
+ *     tags:
+ *       - Feeds
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - urls
+ *             properties:
+ *               urls:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *                   format: uri
+ *     responses:
+ *       '200':
+ *         description: Result of the bulk creation request
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Envelope'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       $ref: '#/components/schemas/FeedBulkResult'
+ */
+router.post('/feeds/bulk', feedController.bulkCreate);
+
+/**
+ * @openapi
+ * /api/v1/feeds/{id}:
+ *   patch:
+ *     summary: Update attributes of an existing feed
+ *     tags:
+ *       - Feeds
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               url:
+ *                 type: string
+ *                 format: uri
+ *               title:
+ *                 type: string
+ *                 nullable: true
+ *     responses:
+ *       '200':
+ *         description: Feed updated successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Envelope'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       $ref: '#/components/schemas/Feed'
+ *   delete:
+ *     summary: Remove a feed owned by the authenticated user
+ *     tags:
+ *       - Feeds
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       '200':
+ *         description: Feed removed successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Envelope'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       type: object
+ *                       properties:
+ *                         message:
+ *                           type: string
+ */
+router.patch('/feeds/:id', feedController.update);
+router.delete('/feeds/:id', feedController.remove);
+
+module.exports = router;

--- a/backend/src/routes/v1/index.js
+++ b/backend/src/routes/v1/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
-const helloRoutes = require('./hello.routes');
 const authRoutes = require('./auth.routes');
+const helloRoutes = require('./hello.routes');
+const feedRoutes = require('./feed.routes');
 const allowlistRoutes = require('./allowlist.routes');
 const { requireAuth } = require('../../middlewares/authentication');
 const { requireRole, ROLES } = require('../../middlewares/authorization');
@@ -8,8 +9,9 @@ const { requireRole, ROLES } = require('../../middlewares/authorization');
 const router = express.Router();
 
 router.use('/auth', authRoutes);
-router.use(helloRoutes);
 router.use(requireAuth);
+router.use(helloRoutes);
+router.use(feedRoutes);
 router.use('/allowlist', requireRole(ROLES.ADMIN), allowlistRoutes);
 
 module.exports = router;

--- a/backend/src/services/feed.service.js
+++ b/backend/src/services/feed.service.js
@@ -1,0 +1,243 @@
+const ApiError = require('../utils/api-error');
+const { prisma } = require('../lib/prisma');
+
+const MAX_PAGE_SIZE = 50;
+
+const sanitizeString = (value) => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const normalizeTitle = (title) => {
+  if (title === undefined) {
+    return undefined;
+  }
+
+  const sanitized = sanitizeString(title);
+  return sanitized.length > 0 ? sanitized : null;
+};
+
+const ensureValidUrl = (input, { required = true } = {}) => {
+  const sanitized = sanitizeString(input);
+
+  if (!sanitized) {
+    if (!required) {
+      return null;
+    }
+
+    throw new ApiError({ statusCode: 400, code: 'URL_REQUIRED', message: 'URL is required' });
+  }
+
+  try {
+    const parsed = new URL(sanitized);
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      throw new Error('Unsupported protocol');
+    }
+  } catch (error) {
+    throw new ApiError({ statusCode: 400, code: 'INVALID_URL', message: 'Invalid URL provided' });
+  }
+
+  return sanitized;
+};
+
+const filterOwnerFeed = async (id, ownerKey) => {
+  const feed = await prisma.feed.findUnique({ where: { id } });
+
+  if (!feed || feed.ownerKey !== ownerKey) {
+    throw new ApiError({ statusCode: 404, code: 'FEED_NOT_FOUND', message: 'Feed not found' });
+  }
+
+  return feed;
+};
+
+const listFeeds = async ({ ownerKey, cursor, limit }) => {
+  const safeLimit = Math.min(Math.max(limit ?? 20, 1), MAX_PAGE_SIZE);
+
+  const query = {
+    where: { ownerKey },
+    orderBy: { id: 'asc' },
+    take: safeLimit + 1,
+  };
+
+  if (cursor) {
+    query.cursor = { id: cursor };
+    query.skip = 1;
+  }
+
+  const feeds = await prisma.feed.findMany(query);
+  const hasMore = feeds.length > safeLimit;
+  const items = hasMore ? feeds.slice(0, safeLimit) : feeds;
+  const nextCursor = hasMore ? items[items.length - 1].id : null;
+  const total = await prisma.feed.count({ where: { ownerKey } });
+
+  return {
+    items,
+    nextCursor,
+    total,
+    limit: safeLimit,
+  };
+};
+
+const createFeed = async ({ ownerKey, url, title }) => {
+  const normalizedUrl = ensureValidUrl(url);
+  const normalizedTitle = normalizeTitle(title);
+
+  const existing = await prisma.feed.findUnique({
+    where: {
+      ownerKey_url: { ownerKey, url: normalizedUrl },
+    },
+  });
+
+  if (existing) {
+    throw new ApiError({ statusCode: 409, code: 'FEED_ALREADY_EXISTS', message: 'Feed already exists for this user' });
+  }
+
+  const created = await prisma.feed.create({
+    data: {
+      ownerKey,
+      url: normalizedUrl,
+      title: normalizedTitle ?? undefined,
+    },
+  });
+
+  return created;
+};
+
+const analyzeUrlCandidate = (value) => {
+  const sanitized = sanitizeString(value);
+
+  if (!sanitized) {
+    return { ok: false, url: '', reason: 'URL_REQUIRED' };
+  }
+
+  try {
+    const parsed = new URL(sanitized);
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      return { ok: false, url: sanitized, reason: 'INVALID_URL' };
+    }
+  } catch (error) {
+    return { ok: false, url: sanitized, reason: 'INVALID_URL' };
+  }
+
+  return { ok: true, url: sanitized };
+};
+
+const createFeedsInBulk = async ({ ownerKey, urls }) => {
+  const result = {
+    created: [],
+    duplicates: [],
+    invalid: [],
+  };
+
+  if (!Array.isArray(urls)) {
+    throw new ApiError({ statusCode: 400, code: 'INVALID_PAYLOAD', message: 'urls must be an array of strings' });
+  }
+
+  const seen = new Set();
+  const candidates = [];
+
+  urls.forEach((candidate) => {
+    const analysis = analyzeUrlCandidate(candidate);
+
+    if (!analysis.ok) {
+      result.invalid.push({ url: analysis.url, reason: analysis.reason });
+      return;
+    }
+
+    if (seen.has(analysis.url)) {
+      result.duplicates.push({ url: analysis.url, reason: 'DUPLICATE_IN_PAYLOAD', feedId: null });
+      return;
+    }
+
+    seen.add(analysis.url);
+    candidates.push(analysis.url);
+  });
+
+  if (candidates.length === 0) {
+    return result;
+  }
+
+  const existingFeeds = await prisma.feed.findMany({
+    where: {
+      ownerKey,
+      url: { in: candidates },
+    },
+  });
+
+  const existingByUrl = new Map();
+  existingFeeds.forEach((feed) => {
+    existingByUrl.set(feed.url, feed);
+    result.duplicates.push({ url: feed.url, reason: 'ALREADY_EXISTS', feedId: feed.id });
+  });
+
+  const urlsToCreate = candidates.filter((url) => !existingByUrl.has(url));
+
+  for (const url of urlsToCreate) {
+    const created = await prisma.feed.create({
+      data: {
+        ownerKey,
+        url,
+      },
+    });
+
+    result.created.push(created);
+  }
+
+  return result;
+};
+
+const updateFeed = async ({ ownerKey, feedId, url, title }) => {
+  const existing = await filterOwnerFeed(feedId, ownerKey);
+
+  const data = {};
+
+  if (url !== undefined) {
+    const normalizedUrl = ensureValidUrl(url);
+
+    if (normalizedUrl !== existing.url) {
+      const duplicate = await prisma.feed.findUnique({
+        where: {
+          ownerKey_url: { ownerKey, url: normalizedUrl },
+        },
+      });
+
+      if (duplicate && duplicate.id !== feedId) {
+        throw new ApiError({ statusCode: 409, code: 'FEED_ALREADY_EXISTS', message: 'Feed already exists for this user' });
+      }
+
+      data.url = normalizedUrl;
+    }
+  }
+
+  if (title !== undefined) {
+    data.title = normalizeTitle(title);
+  }
+
+  if (Object.keys(data).length === 0) {
+    return existing;
+  }
+
+  const updated = await prisma.feed.update({
+    where: { id: feedId },
+    data,
+  });
+
+  return updated;
+};
+
+const deleteFeed = async ({ ownerKey, feedId }) => {
+  await filterOwnerFeed(feedId, ownerKey);
+
+  await prisma.feed.delete({ where: { id: feedId } });
+};
+
+module.exports = {
+  listFeeds,
+  createFeed,
+  createFeedsInBulk,
+  updateFeed,
+  deleteFeed,
+};

--- a/backend/tests/feeds.e2e.test.js
+++ b/backend/tests/feeds.e2e.test.js
@@ -1,0 +1,238 @@
+const request = require('supertest');
+
+jest.mock('../src/services/auth.service', () => {
+  const actual = jest.requireActual('../src/services/auth.service');
+  return {
+    ...actual,
+    validateSessionToken: jest.fn(),
+  };
+});
+
+const app = require('../src/app');
+const authService = require('../src/services/auth.service');
+const feedService = require('../src/services/feed.service');
+const { prisma } = require('../src/lib/prisma');
+
+const ORIGIN = 'http://localhost:5173';
+const TOKENS = {
+  user1: 'token-user-1',
+  user2: 'token-user-2',
+};
+
+const sessionForUser = (userId, email) => ({
+  session: {
+    id: `session-${userId}`,
+    userId,
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    user: {
+      id: userId,
+      email,
+      role: 'user',
+    },
+  },
+  renewed: false,
+});
+
+const withAuth = (token, req) => req.set('Origin', ORIGIN).set('Authorization', `Bearer ${token}`);
+
+describe('Feeds API', () => {
+  beforeEach(() => {
+    prisma.__reset();
+
+    authService.validateSessionToken.mockImplementation(async ({ token }) => {
+      if (token === TOKENS.user1) {
+        return sessionForUser(1, 'user1@example.com');
+      }
+
+      if (token === TOKENS.user2) {
+        return sessionForUser(2, 'user2@example.com');
+      }
+
+      return null;
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('GET /api/v1/feeds', () => {
+    it('returns only feeds owned by the authenticated user with pagination metadata', async () => {
+      await feedService.createFeed({ ownerKey: '1', url: 'https://example.com/feed-1.xml', title: 'Feed 1' });
+      await feedService.createFeed({ ownerKey: '1', url: 'https://example.com/feed-2.xml', title: 'Feed 2' });
+      await feedService.createFeed({ ownerKey: '1', url: 'https://example.com/feed-3.xml', title: 'Feed 3' });
+      await feedService.createFeed({ ownerKey: '2', url: 'https://others.com/feed.xml', title: 'Other' });
+
+      const firstPage = await withAuth(TOKENS.user1, request(app).get('/api/v1/feeds'))
+        .query({ limit: 2 })
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      expect(firstPage.body.data.items).toHaveLength(2);
+      expect(firstPage.body.data.items.map((item) => item.url)).toEqual([
+        'https://example.com/feed-1.xml',
+        'https://example.com/feed-2.xml',
+      ]);
+      expect(firstPage.body.meta).toEqual(
+        expect.objectContaining({
+          nextCursor: expect.any(String),
+          total: 3,
+          limit: 2,
+        })
+      );
+
+      const nextCursor = firstPage.body.meta.nextCursor;
+
+      const secondPage = await withAuth(TOKENS.user1, request(app).get('/api/v1/feeds'))
+        .query({ cursor: nextCursor })
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      expect(secondPage.body.data.items).toHaveLength(1);
+      expect(secondPage.body.data.items[0]).toEqual(
+        expect.objectContaining({ url: 'https://example.com/feed-3.xml', title: 'Feed 3' })
+      );
+      expect(secondPage.body.meta.nextCursor).toBeNull();
+    });
+  });
+
+  describe('POST /api/v1/feeds', () => {
+    it('creates a feed when a valid URL is provided', async () => {
+      const response = await withAuth(TOKENS.user1, request(app).post('/api/v1/feeds'))
+        .send({ url: ' https://news.example.com/rss ', title: '  News  ' })
+        .expect('Content-Type', /json/)
+        .expect(201);
+
+      expect(response.body.data).toEqual(
+        expect.objectContaining({
+          url: 'https://news.example.com/rss',
+          title: 'News',
+          lastFetchedAt: null,
+        })
+      );
+    });
+
+    it('rejects duplicate feeds for the same user', async () => {
+      await feedService.createFeed({ ownerKey: '1', url: 'https://duplicate.example.com/rss' });
+
+      const response = await withAuth(TOKENS.user1, request(app).post('/api/v1/feeds'))
+        .send({ url: 'https://duplicate.example.com/rss' })
+        .expect('Content-Type', /json/)
+        .expect(409);
+
+      expect(response.body.error.code).toBe('FEED_ALREADY_EXISTS');
+    });
+
+    it('rejects invalid URLs', async () => {
+      const response = await withAuth(TOKENS.user1, request(app).post('/api/v1/feeds'))
+        .send({ url: 'invalid-url' })
+        .expect('Content-Type', /json/)
+        .expect(400);
+
+      expect(response.body.error.code).toBe('INVALID_URL');
+    });
+  });
+
+  describe('POST /api/v1/feeds/bulk', () => {
+    it('classifies created, duplicate and invalid URLs correctly', async () => {
+      await feedService.createFeed({ ownerKey: '1', url: 'https://existing.example.com/rss' });
+
+      const response = await withAuth(TOKENS.user1, request(app).post('/api/v1/feeds/bulk'))
+        .send({
+          urls: [
+            '   ',
+            'https://existing.example.com/rss',
+            'https://bulk.example.com/a',
+            'https://bulk.example.com/a',
+            'ftp://invalid.example.com/rss',
+            'https://bulk.example.com/b',
+            'not-a-url',
+          ],
+        })
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      expect(response.body.data.created).toHaveLength(2);
+      expect(response.body.data.created.map((feed) => feed.url)).toEqual([
+        'https://bulk.example.com/a',
+        'https://bulk.example.com/b',
+      ]);
+
+      expect(response.body.data.duplicates).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ url: 'https://existing.example.com/rss', reason: 'ALREADY_EXISTS' }),
+          expect.objectContaining({ url: 'https://bulk.example.com/a', reason: 'DUPLICATE_IN_PAYLOAD' }),
+        ])
+      );
+
+      expect(response.body.data.invalid).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ reason: 'URL_REQUIRED' }),
+          expect.objectContaining({ url: 'ftp://invalid.example.com/rss', reason: 'INVALID_URL' }),
+          expect.objectContaining({ url: 'not-a-url', reason: 'INVALID_URL' }),
+        ])
+      );
+    });
+  });
+
+  describe('PATCH /api/v1/feeds/:id', () => {
+    it('updates the title of an existing feed', async () => {
+      const feed = await feedService.createFeed({ ownerKey: '1', url: 'https://update.example.com/rss', title: 'Old' });
+
+      const response = await withAuth(TOKENS.user1, request(app).patch(`/api/v1/feeds/${feed.id}`))
+        .send({ title: 'New Title' })
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      expect(response.body.data).toEqual(
+        expect.objectContaining({
+          id: feed.id,
+          title: 'New Title',
+          url: 'https://update.example.com/rss',
+        })
+      );
+    });
+
+    it('rejects updates that would duplicate another feed URL', async () => {
+      const original = await feedService.createFeed({ ownerKey: '1', url: 'https://keep.example.com/rss' });
+      const target = await feedService.createFeed({ ownerKey: '1', url: 'https://change.example.com/rss' });
+
+      const response = await withAuth(TOKENS.user1, request(app).patch(`/api/v1/feeds/${target.id}`))
+        .send({ url: original.url })
+        .expect('Content-Type', /json/)
+        .expect(409);
+
+      expect(response.body.error.code).toBe('FEED_ALREADY_EXISTS');
+    });
+
+    it('returns 404 when editing a feed owned by another user', async () => {
+      const foreignFeed = await feedService.createFeed({ ownerKey: '2', url: 'https://foreign.example.com/rss' });
+
+      await withAuth(TOKENS.user1, request(app).patch(`/api/v1/feeds/${foreignFeed.id}`))
+        .send({ title: 'Unauthorized' })
+        .expect('Content-Type', /json/)
+        .expect(404);
+    });
+  });
+
+  describe('DELETE /api/v1/feeds/:id', () => {
+    it('removes a feed owned by the authenticated user', async () => {
+      const feed = await feedService.createFeed({ ownerKey: '1', url: 'https://delete.example.com/rss' });
+
+      await withAuth(TOKENS.user1, request(app).delete(`/api/v1/feeds/${feed.id}`))
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      const list = await feedService.listFeeds({ ownerKey: '1', limit: 10 });
+      expect(list.items).toHaveLength(0);
+    });
+
+    it('returns 404 when deleting a feed owned by another user', async () => {
+      const foreignFeed = await feedService.createFeed({ ownerKey: '2', url: 'https://other.example.com/rss' });
+
+      await withAuth(TOKENS.user1, request(app).delete(`/api/v1/feeds/${foreignFeed.id}`))
+        .expect('Content-Type', /json/)
+        .expect(404);
+    });
+  });
+});

--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -1,3 +1,126 @@
 process.env.NODE_ENV = 'test';
 process.env.CORS_ALLOWED_ORIGINS = process.env.CORS_ALLOWED_ORIGINS || 'http://localhost:5173';
 process.env.ENABLE_METRICS = process.env.ENABLE_METRICS || 'false';
+
+jest.mock('../src/lib/prisma', () => {
+  const feeds = [];
+  let idCounter = 1;
+
+  const clone = (entity) => ({ ...entity });
+
+  const filterFeeds = (where = {}) => {
+    let result = feeds.slice();
+
+    if (where.ownerKey) {
+      result = result.filter((feed) => feed.ownerKey === where.ownerKey);
+    }
+
+    if (where.id != null) {
+      result = result.filter((feed) => feed.id === where.id);
+    }
+
+    if (where.url) {
+      if (Array.isArray(where.url.in)) {
+        result = result.filter((feed) => where.url.in.includes(feed.url));
+      } else if (typeof where.url === 'string') {
+        result = result.filter((feed) => feed.url === where.url);
+      }
+    }
+
+    return result;
+  };
+
+  const prisma = {
+    feed: {
+      findMany: async ({ where = {}, orderBy, take, skip, cursor } = {}) => {
+        let result = filterFeeds(where);
+
+        if (orderBy?.id === 'asc') {
+          result = result.slice().sort((a, b) => a.id - b.id);
+        }
+
+        if (cursor?.id != null) {
+          const index = result.findIndex((feed) => feed.id === cursor.id);
+          if (index === -1) {
+            result = [];
+          } else {
+            const skipCount = typeof skip === 'number' ? skip : 0;
+            result = result.slice(index + skipCount);
+          }
+        }
+
+        if (typeof take === 'number') {
+          result = take >= 0 ? result.slice(0, take) : [];
+        }
+
+        return result.map(clone);
+      },
+      count: async ({ where = {} } = {}) => filterFeeds(where).length,
+      findUnique: async ({ where }) => {
+        if (where.id != null) {
+          const found = feeds.find((feed) => feed.id === where.id);
+          return found ? clone(found) : null;
+        }
+
+        if (where.ownerKey_url) {
+          const { ownerKey, url } = where.ownerKey_url;
+          const found = feeds.find((feed) => feed.ownerKey === ownerKey && feed.url === url);
+          return found ? clone(found) : null;
+        }
+
+        return null;
+      },
+      create: async ({ data }) => {
+        const now = new Date();
+        const record = {
+          id: idCounter++,
+          ownerKey: data.ownerKey,
+          url: data.url,
+          title: data.title ?? null,
+          lastFetchedAt: data.lastFetchedAt ?? null,
+          createdAt: now,
+          updatedAt: now,
+        };
+
+        feeds.push(record);
+
+        return clone(record);
+      },
+      update: async ({ where, data }) => {
+        const index = feeds.findIndex((feed) => feed.id === where.id);
+
+        if (index === -1) {
+          throw new Error('Feed not found');
+        }
+
+        const now = new Date();
+        feeds[index] = {
+          ...feeds[index],
+          ...data,
+          updatedAt: now,
+        };
+
+        return clone(feeds[index]);
+      },
+      delete: async ({ where }) => {
+        const index = feeds.findIndex((feed) => feed.id === where.id);
+
+        if (index === -1) {
+          throw new Error('Feed not found');
+        }
+
+        const [removed] = feeds.splice(index, 1);
+        return clone(removed);
+      },
+    },
+    helloMessage: {
+      findFirst: async () => null,
+    },
+    __reset: () => {
+      feeds.splice(0, feeds.length);
+      idCounter = 1;
+    },
+  };
+
+  return { prisma, disconnectDatabase: jest.fn() };
+});


### PR DESCRIPTION
## Summary
- add feed service and controller to list, create, bulk create, update and delete RSS feeds per owner
- expose authenticated /api/v1/feeds endpoints with OpenAPI docs and pagination metadata
- provide prisma test double and API tests covering feed scenarios and ownership guards

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0248c38c08325a2abe36621d0a02a