### PR TITLE
feat: add posts refresh cleanup and listing APIs

### DIFF
--- a/backend/docs/endpoints.md
+++ b/backend/docs/endpoints.md
@@ -1,11 +1,14 @@
 ﻿# Catálogo de Endpoints
 
-| Método | Caminho             | Descrição                            | Autenticação |
-|--------|---------------------|----------------------------------------|--------------|
-| GET    | /health/live        | Verifica se o serviço está vivo        | Não          |
-| GET    | /health/ready       | Verifica se o serviço está pronto      | Não          |
-| GET    | /metrics            | Retorna métricas Prometheus            | Não*         |
-| GET    | /docs               | Interface Swagger/OpenAPI              | Não          |
-| GET    | /api/v1/hello       | Retorna a mensagem hello mundo         | Não          |
+| Método | Caminho                  | Descrição                                                       | Autenticação |
+|--------|--------------------------|-------------------------------------------------------------------|--------------|
+| GET    | /health/live             | Verifica se o serviço está vivo                                   | Não          |
+| GET    | /health/ready            | Verifica se o serviço está pronto                                 | Não          |
+| GET    | /metrics                 | Retorna métricas Prometheus                                       | Não*         |
+| GET    | /docs                    | Interface Swagger/OpenAPI                                         | Não          |
+| GET    | /api/v1/hello            | Retorna a mensagem hello mundo                                    | Não          |
+| POST   | /api/v1/posts/refresh    | Atualiza os feeds do usuário e cria novos artigos/posts recentes  | Sim          |
+| POST   | /api/v1/posts/cleanup    | Remove artigos antigos (>7 dias) e seus posts associados          | Sim          |
+| GET    | /api/v1/posts            | Lista artigos recentes (≤7 dias) com posts e metadados paginados  | Sim          |
 
 > \* Recomenda-se proteger /metrics com autenticação na produção.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,6 +18,7 @@
                 "dotenv": "^17.2.2",
                 "express": "^4.21.2",
                 "express-rate-limit": "^8.1.0",
+                "fast-xml-parser": "^4.5.1",
                 "google-auth-library": "^9.15.1",
                 "helmet": "^8.1.0",
                 "hpp": "^0.2.3",
@@ -3555,6 +3556,28 @@
             "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
             "dev": true
         },
+        "node_modules/fast-xml-parser": {
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.1.tgz",
+            "integrity": "sha512-y655CeyUQ+jj7KBbYMc4FG01V8ZQqjN+gDYGJ50RtfsUB8iG9AmwmwoAgeKLJdmueKKMrH1RJ7yXHTSoczdv5w==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/naturalintelligence"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "strnum": "^1.0.5"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
+            }
+        },
         "node_modules/fastq": {
             "version": "1.19.1",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -6767,6 +6790,18 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/strnum": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+            "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/superagent": {
             "version": "10.2.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -37,6 +37,7 @@
         "dotenv": "^17.2.2",
         "express": "^4.21.2",
         "express-rate-limit": "^8.1.0",
+        "fast-xml-parser": "^4.5.1",
         "google-auth-library": "^9.15.1",
         "helmet": "^8.1.0",
         "hpp": "^0.2.3",

--- a/backend/src/controllers/posts.controller.js
+++ b/backend/src/controllers/posts.controller.js
@@ -1,0 +1,118 @@
+const asyncHandler = require('../utils/async-handler');
+const ApiError = require('../utils/api-error');
+const postsService = require('../services/posts.service');
+
+const parsePositiveInteger = (value, { field = 'id', required = false } = {}) => {
+  if (value === undefined || value === null || value === '') {
+    if (required) {
+      throw new ApiError({ statusCode: 400, code: 'INVALID_INPUT', message: `Invalid ${field}` });
+    }
+
+    return null;
+  }
+
+  const number = Number(value);
+
+  if (!Number.isInteger(number) || number <= 0) {
+    throw new ApiError({ statusCode: 400, code: 'INVALID_INPUT', message: `Invalid ${field}` });
+  }
+
+  return number;
+};
+
+const getOwnerKey = (req) => {
+  if (!req.user || req.user.id == null) {
+    throw new ApiError({ statusCode: 401, code: 'UNAUTHENTICATED', message: 'Authentication required' });
+  }
+
+  return String(req.user.id);
+};
+
+const mapFeedSummary = (entry) => ({
+  feedId: entry.feedId,
+  feedUrl: entry.feedUrl,
+  feedTitle: entry.feedTitle,
+  skippedByCooldown: entry.skippedByCooldown,
+  cooldownSecondsRemaining: entry.cooldownSecondsRemaining,
+  itemsRead: entry.itemsRead,
+  itemsWithinWindow: entry.itemsWithinWindow,
+  articlesCreated: entry.articlesCreated,
+  duplicates: entry.duplicates,
+  invalidItems: entry.invalidItems,
+  error: entry.error ? entry.error.message : null,
+});
+
+const mapPostListItem = (article) => ({
+  id: article.id,
+  title: article.title,
+  contentSnippet: article.contentSnippet,
+  publishedAt: article.publishedAt instanceof Date ? article.publishedAt.toISOString() : article.publishedAt,
+  feed: article.feed
+    ? {
+        id: article.feed.id,
+        title: article.feed.title ?? null,
+        url: article.feed.url ?? null,
+      }
+    : null,
+  post: article.post
+    ? {
+        content: article.post.content,
+        createdAt:
+          article.post.createdAt instanceof Date
+            ? article.post.createdAt.toISOString()
+            : article.post.createdAt ?? null,
+      }
+    : null,
+});
+
+const refresh = asyncHandler(async (req, res) => {
+  const ownerKey = getOwnerKey(req);
+  const result = await postsService.refreshUserFeeds({ ownerKey });
+
+  return res.success({
+    now: result.now.toISOString(),
+    feeds: result.results.map(mapFeedSummary),
+  });
+});
+
+const cleanup = asyncHandler(async (req, res) => {
+  const ownerKey = getOwnerKey(req);
+  const result = await postsService.cleanupOldArticles({ ownerKey });
+
+  return res.success(result);
+});
+
+const list = asyncHandler(async (req, res) => {
+  const ownerKey = getOwnerKey(req);
+  const cursor = typeof req.query.cursor === 'string' && req.query.cursor.length > 0 ? req.query.cursor : null;
+  const limit = req.query.limit != null ? parsePositiveInteger(req.query.limit, { field: 'limit' }) : undefined;
+  const feedId = req.query.feedId != null ? parsePositiveInteger(req.query.feedId, { field: 'feedId' }) : null;
+
+  try {
+    const result = await postsService.listRecentArticles({ ownerKey, cursor, limit, feedId: feedId ?? undefined });
+
+    return res.success(
+      {
+        items: result.items.map(mapPostListItem),
+      },
+      {
+        meta: {
+          nextCursor: result.nextCursor,
+          limit: result.limit,
+        },
+      }
+    );
+  } catch (error) {
+    if (error instanceof postsService.InvalidCursorError) {
+      throw new ApiError({ statusCode: 400, code: 'INVALID_CURSOR', message: 'Invalid pagination cursor' });
+    }
+
+    throw error;
+  }
+});
+
+module.exports = {
+  refresh,
+  cleanup,
+  list,
+};

--- a/backend/src/routes/v1/index.js
+++ b/backend/src/routes/v1/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const authRoutes = require('./auth.routes');
 const helloRoutes = require('./hello.routes');
 const feedRoutes = require('./feed.routes');
+const postsRoutes = require('./posts.routes');
 const allowlistRoutes = require('./allowlist.routes');
 const { requireAuth } = require('../../middlewares/authentication');
 const { requireRole, ROLES } = require('../../middlewares/authorization');
@@ -12,6 +13,7 @@ router.use('/auth', authRoutes);
 router.use(requireAuth);
 router.use(helloRoutes);
 router.use(feedRoutes);
+router.use(postsRoutes);
 router.use('/allowlist', requireRole(ROLES.ADMIN), allowlistRoutes);
 
 module.exports = router;

--- a/backend/src/routes/v1/posts.routes.js
+++ b/backend/src/routes/v1/posts.routes.js
@@ -1,0 +1,11 @@
+const express = require('express');
+
+const postsController = require('../../controllers/posts.controller');
+
+const router = express.Router();
+
+router.post('/posts/refresh', postsController.refresh);
+router.post('/posts/cleanup', postsController.cleanup);
+router.get('/posts', postsController.list);
+
+module.exports = router;

--- a/backend/src/services/posts.service.js
+++ b/backend/src/services/posts.service.js
@@ -1,0 +1,608 @@
+const { XMLParser } = require('fast-xml-parser');
+const { createHash } = require('crypto');
+
+const { prisma } = require('../lib/prisma');
+
+const COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
+const WINDOW_DAYS = 7;
+const WINDOW_MS = WINDOW_DAYS * 24 * 60 * 60 * 1000;
+const DEFAULT_FETCH_TIMEOUT_MS = 10_000;
+const MAX_PAGE_SIZE = 50;
+
+const POST_PLACEHOLDER_CONTENT = [
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+  'Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+  'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.',
+  'Nisi ut aliquip ex ea commodo consequat.',
+  'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum.',
+  'Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia.',
+].join('\n');
+
+class InvalidCursorError extends Error {
+  constructor(message = 'Invalid pagination cursor') {
+    super(message);
+    this.name = 'InvalidCursorError';
+    this.code = 'INVALID_CURSOR';
+  }
+}
+
+const normalizeDate = (value) => {
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) {
+      return null;
+    }
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
+  if (typeof value === 'string') {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
+  return null;
+};
+
+const ensureDate = (value) => {
+  const date = normalizeDate(value ?? new Date());
+  if (!date) {
+    throw new Error('Invalid date value provided');
+  }
+  return date;
+};
+
+const ensureArray = (value) => {
+  if (value == null) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+};
+
+const extractText = (value) => {
+  if (value == null) {
+    return '';
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const text = extractText(entry);
+      if (text) {
+        return text;
+      }
+    }
+    return '';
+  }
+
+  if (typeof value === 'object') {
+    if (Object.prototype.hasOwnProperty.call(value, '#text')) {
+      return extractText(value['#text']);
+    }
+    if (Object.prototype.hasOwnProperty.call(value, '_text')) {
+      return extractText(value._text);
+    }
+    if (Object.prototype.hasOwnProperty.call(value, 'text')) {
+      return extractText(value.text);
+    }
+    if (Object.prototype.hasOwnProperty.call(value, 'value')) {
+      return extractText(value.value);
+    }
+  }
+
+  return String(value);
+};
+
+const stripHtml = (value) => {
+  if (!value) {
+    return '';
+  }
+
+  return value.replace(/<[^>]+>/g, ' ');
+};
+
+const cleanText = (value) => stripHtml(value).replace(/\s+/g, ' ').trim();
+
+const truncateText = (value, maxLength) => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  if (value.length <= maxLength) {
+    return value;
+  }
+
+  return `${value.slice(0, maxLength - 1)}…`;
+};
+
+const sanitizeIdentifier = (value) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const parsePublishedAt = (item) => {
+  const publishedSources = [
+    item.pubDate,
+    item.published,
+    item.updated,
+    item.lastBuildDate,
+    item['dc:date'],
+  ];
+
+  for (const candidate of publishedSources) {
+    const normalized = extractText(candidate);
+    const parsed = normalizeDate(normalized);
+    if (parsed) {
+      return parsed;
+    }
+  }
+
+  return null;
+};
+
+const extractLink = (rawLink) => {
+  if (rawLink == null) {
+    return null;
+  }
+
+  if (typeof rawLink === 'string') {
+    return sanitizeIdentifier(rawLink);
+  }
+
+  if (Array.isArray(rawLink)) {
+    for (const entry of rawLink) {
+      const link = extractLink(entry);
+      if (link) {
+        return link;
+      }
+    }
+    return null;
+  }
+
+  if (typeof rawLink === 'object') {
+    if (typeof rawLink.href === 'string') {
+      return sanitizeIdentifier(rawLink.href);
+    }
+
+    if (typeof rawLink['@_href'] === 'string') {
+      const rel = typeof rawLink['@_rel'] === 'string' ? rawLink['@_rel'].trim().toLowerCase() : null;
+      if (!rel || rel === 'alternate' || rel === 'self') {
+        return sanitizeIdentifier(rawLink['@_href']);
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(rawLink, '#text')) {
+      return extractLink(rawLink['#text']);
+    }
+  }
+
+  return null;
+};
+
+const buildContentSnippet = (item) => {
+  const candidates = [
+    item.description,
+    item.summary,
+    item['content:encoded'],
+    item.content,
+  ];
+
+  for (const candidate of candidates) {
+    const text = cleanText(extractText(candidate));
+    if (text) {
+      return truncateText(text, 600);
+    }
+  }
+
+  return '';
+};
+
+const normalizeFeedItem = (rawItem) => {
+  const publishedAt = parsePublishedAt(rawItem);
+  if (!publishedAt) {
+    return null;
+  }
+
+  const title = cleanText(extractText(rawItem.title));
+  const contentSnippet = buildContentSnippet(rawItem) || (title ? title : '');
+  const guid = sanitizeIdentifier(extractText(rawItem.guid));
+  const link = extractLink(rawItem.link);
+
+  if (!title && !contentSnippet) {
+    return null;
+  }
+
+  return {
+    title: title || 'Untitled',
+    contentSnippet: contentSnippet || 'No description available.',
+    publishedAt,
+    guid,
+    link,
+  };
+};
+
+const extractItemsFromParsedFeed = (parsed) => {
+  if (!parsed || typeof parsed !== 'object') {
+    return [];
+  }
+
+  if (parsed.feed && parsed.feed.entry) {
+    return ensureArray(parsed.feed.entry);
+  }
+
+  if (parsed.rss && parsed.rss.channel) {
+    const channels = ensureArray(parsed.rss.channel);
+    const items = [];
+    channels.forEach((channel) => {
+      ensureArray(channel.item).forEach((item) => items.push(item));
+    });
+    return items;
+  }
+
+  if (parsed.channel && parsed.channel.item) {
+    return ensureArray(parsed.channel.item);
+  }
+
+  if (parsed.item) {
+    return ensureArray(parsed.item);
+  }
+
+  return [];
+};
+
+const parserOptions = {
+  ignoreAttributes: false,
+  attributeNamePrefix: '@_',
+  textNodeName: '#text',
+  trimValues: true,
+  parseTagValue: false,
+};
+
+const parser = new XMLParser(parserOptions);
+
+const fetchAndParseFeed = async (url, fetcher, timeoutMs) => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetcher(url, {
+      signal: controller.signal,
+      headers: {
+        accept: 'application/rss+xml, application/atom+xml, application/xml;q=0.9, text/xml;q=0.8, */*;q=0.1',
+        'user-agent': 'lkdposts-bot/1.0',
+      },
+    });
+
+    if (!response || typeof response.text !== 'function') {
+      throw new Error('Invalid response from feed fetcher');
+    }
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch feed: HTTP ${response.status}`);
+    }
+
+    const body = await response.text();
+    if (typeof body !== 'string') {
+      throw new Error('Feed response was not text');
+    }
+
+    let parsed;
+    try {
+      parsed = parser.parse(body);
+    } catch (error) {
+      throw new Error('Failed to parse feed XML');
+    }
+
+    const rawItems = extractItemsFromParsedFeed(parsed);
+    const items = [];
+    let invalidItems = 0;
+
+    rawItems.forEach((raw) => {
+      const normalized = normalizeFeedItem(raw);
+      if (normalized) {
+        items.push(normalized);
+      } else {
+        invalidItems += 1;
+      }
+    });
+
+    items.sort((a, b) => a.publishedAt.getTime() - b.publishedAt.getTime());
+
+    return {
+      rawCount: rawItems.length,
+      items,
+      invalidItems,
+    };
+  } catch (error) {
+    if (error && error.name === 'AbortError') {
+      throw new Error('Feed request timed out');
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+const computeDedupeKey = (item) => {
+  if (item.guid) {
+    return `guid:${item.guid}`;
+  }
+
+  if (item.link) {
+    return `link:${item.link}`;
+  }
+
+  const hash = createHash('sha256')
+    .update(item.title || '')
+    .update('|')
+    .update(item.contentSnippet || '')
+    .update('|')
+    .update(item.publishedAt.toISOString())
+    .digest('hex');
+
+  return `hash:${hash}`;
+};
+
+const refreshUserFeeds = async ({ ownerKey, now = new Date(), fetcher, timeoutMs = DEFAULT_FETCH_TIMEOUT_MS }) => {
+  if (!ownerKey) {
+    throw new Error('ownerKey is required');
+  }
+
+  const fetchImpl = fetcher || globalThis.fetch;
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('No fetch implementation available');
+  }
+
+  const currentTime = ensureDate(now);
+  const windowStart = new Date(currentTime.getTime() - WINDOW_MS);
+
+  const feeds = await prisma.feed.findMany({ where: { ownerKey } });
+  const results = [];
+
+  for (const feed of feeds) {
+    const feedSummary = {
+      feedId: feed.id,
+      feedUrl: feed.url,
+      feedTitle: feed.title ?? null,
+      skippedByCooldown: false,
+      cooldownSecondsRemaining: 0,
+      itemsRead: 0,
+      itemsWithinWindow: 0,
+      articlesCreated: 0,
+      duplicates: 0,
+      invalidItems: 0,
+      error: null,
+    };
+
+    const lastFetchedAt = feed.lastFetchedAt ? new Date(feed.lastFetchedAt) : null;
+    if (lastFetchedAt && currentTime.getTime() - lastFetchedAt.getTime() < COOLDOWN_MS) {
+      const remainingMs = COOLDOWN_MS - (currentTime.getTime() - lastFetchedAt.getTime());
+      feedSummary.skippedByCooldown = true;
+      feedSummary.cooldownSecondsRemaining = Math.ceil(remainingMs / 1000);
+      results.push(feedSummary);
+      continue;
+    }
+
+    try {
+      const { rawCount, items, invalidItems } = await fetchAndParseFeed(feed.url, fetchImpl, timeoutMs);
+      feedSummary.itemsRead = rawCount;
+      feedSummary.invalidItems = invalidItems;
+
+      for (const item of items) {
+        if (item.publishedAt.getTime() < windowStart.getTime()) {
+          continue;
+        }
+
+        if (item.publishedAt.getTime() > currentTime.getTime()) {
+          continue;
+        }
+
+        feedSummary.itemsWithinWindow += 1;
+        const dedupeKey = computeDedupeKey(item);
+
+        const existing = await prisma.article.findUnique({
+          where: { feedId_dedupeKey: { feedId: feed.id, dedupeKey } },
+        });
+
+        if (existing) {
+          feedSummary.duplicates += 1;
+          continue;
+        }
+
+        const article = await prisma.article.create({
+          data: {
+            feedId: feed.id,
+            title: item.title,
+            contentSnippet: item.contentSnippet,
+            publishedAt: item.publishedAt,
+            guid: item.guid ?? null,
+            link: item.link ?? null,
+            dedupeKey,
+          },
+        });
+
+        await prisma.post.create({
+          data: {
+            articleId: article.id,
+            content: POST_PLACEHOLDER_CONTENT,
+          },
+        });
+
+        feedSummary.articlesCreated += 1;
+      }
+    } catch (error) {
+      feedSummary.error = { message: error.message };
+    }
+
+    await prisma.feed.update({
+      where: { id: feed.id },
+      data: { lastFetchedAt: currentTime },
+    });
+
+    results.push(feedSummary);
+  }
+
+  return {
+    now: currentTime,
+    results,
+  };
+};
+
+const cleanupOldArticles = async ({ ownerKey, now = new Date() }) => {
+  if (!ownerKey) {
+    throw new Error('ownerKey is required');
+  }
+
+  const currentTime = ensureDate(now);
+  const threshold = new Date(currentTime.getTime() - WINDOW_MS);
+
+  const articlesToRemove = await prisma.article.findMany({
+    where: {
+      feed: { ownerKey },
+      publishedAt: { lt: threshold },
+    },
+    select: { id: true },
+  });
+
+  if (articlesToRemove.length === 0) {
+    return { removedArticles: 0, removedPosts: 0 };
+  }
+
+  const articleIds = articlesToRemove.map((article) => article.id);
+
+  const postsResult = await prisma.post.deleteMany({
+    where: { articleId: { in: articleIds } },
+  });
+
+  const articlesResult = await prisma.article.deleteMany({
+    where: { id: { in: articleIds } },
+  });
+
+  const removedPosts = typeof postsResult === 'number' ? postsResult : postsResult.count ?? 0;
+  const removedArticles = typeof articlesResult === 'number' ? articlesResult : articlesResult.count ?? 0;
+
+  return { removedArticles, removedPosts };
+};
+
+const encodeCursor = (article) => {
+  const payload = `${article.publishedAt.toISOString()}::${article.id}`;
+  return Buffer.from(payload, 'utf8').toString('base64');
+};
+
+const decodeCursor = (cursor) => {
+  try {
+    const decoded = Buffer.from(cursor, 'base64').toString('utf8');
+    const [isoString, idPart] = decoded.split('::');
+    if (!isoString || !idPart) {
+      throw new Error('Invalid cursor payload');
+    }
+
+    const publishedAt = new Date(isoString);
+    const id = Number.parseInt(idPart, 10);
+
+    if (Number.isNaN(publishedAt.getTime()) || !Number.isInteger(id) || id <= 0) {
+      throw new Error('Invalid cursor payload');
+    }
+
+    return { publishedAt, id };
+  } catch (error) {
+    throw new InvalidCursorError();
+  }
+};
+
+const listRecentArticles = async ({ ownerKey, cursor, limit, feedId, now = new Date() }) => {
+  if (!ownerKey) {
+    throw new Error('ownerKey is required');
+  }
+
+  const currentTime = ensureDate(now);
+  const windowStart = new Date(currentTime.getTime() - WINDOW_MS);
+
+  const safeLimit = Math.min(Math.max(limit ?? 20, 1), MAX_PAGE_SIZE);
+
+  let cursorFilter = null;
+  if (cursor) {
+    const parsed = decodeCursor(cursor);
+    cursorFilter = {
+      OR: [
+        { publishedAt: { lt: parsed.publishedAt } },
+        {
+          AND: [
+            { publishedAt: parsed.publishedAt },
+            { id: { lt: parsed.id } },
+          ],
+        },
+      ],
+    };
+  }
+
+  const where = {
+    feed: { ownerKey },
+    publishedAt: {
+      gte: windowStart,
+      lte: currentTime,
+    },
+  };
+
+  if (feedId != null) {
+    where.feedId = feedId;
+  }
+
+  if (cursorFilter) {
+    where.AND = Array.isArray(where.AND) ? [...where.AND, cursorFilter] : [cursorFilter];
+  }
+
+  const articles = await prisma.article.findMany({
+    where,
+    orderBy: [
+      { publishedAt: 'desc' },
+      { id: 'desc' },
+    ],
+    take: safeLimit + 1,
+    include: {
+      post: true,
+      feed: { select: { id: true, title: true, url: true } },
+    },
+  });
+
+  const hasMore = articles.length > safeLimit;
+  const items = hasMore ? articles.slice(0, safeLimit) : articles;
+  const nextCursor = hasMore ? encodeCursor(items[items.length - 1]) : null;
+
+  return {
+    items: items.map((article) => ({
+      id: article.id,
+      title: article.title,
+      contentSnippet: article.contentSnippet,
+      publishedAt: article.publishedAt,
+      feed: article.feed,
+      post: article.post ?? null,
+    })),
+    nextCursor,
+    limit: safeLimit,
+  };
+};
+
+module.exports = {
+  refreshUserFeeds,
+  cleanupOldArticles,
+  listRecentArticles,
+  InvalidCursorError,
+  POST_PLACEHOLDER_CONTENT,
+  constants: {
+    COOLDOWN_MS,
+    WINDOW_DAYS,
+    WINDOW_MS,
+    DEFAULT_FETCH_TIMEOUT_MS,
+    MAX_PAGE_SIZE,
+  },
+};

--- a/backend/tests/posts.e2e.test.js
+++ b/backend/tests/posts.e2e.test.js
@@ -1,0 +1,220 @@
+jest.mock('../src/services/auth.service', () => {
+  const actual = jest.requireActual('../src/services/auth.service');
+  return {
+    ...actual,
+    validateSessionToken: jest.fn(),
+  };
+});
+
+const request = require('supertest');
+
+const app = require('../src/app');
+const authService = require('../src/services/auth.service');
+const { prisma } = require('../src/lib/prisma');
+const postsService = require('../src/services/posts.service');
+
+const ORIGIN = 'http://localhost:5173';
+const TOKENS = {
+  user1: 'token-user-1',
+  user2: 'token-user-2',
+};
+
+const sessionForUser = (userId, email) => ({
+  session: {
+    id: `session-${userId}`,
+    userId,
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    user: {
+      id: userId,
+      email,
+      role: 'user',
+    },
+  },
+  renewed: false,
+});
+
+const withAuth = (token, req) => req.set('Origin', ORIGIN).set('Authorization', `Bearer ${token}`);
+
+describe('Posts API', () => {
+  let originalFetch;
+
+  beforeEach(() => {
+    prisma.__reset();
+
+    authService.validateSessionToken.mockImplementation(async ({ token }) => {
+      if (token === TOKENS.user1) {
+        return sessionForUser(1, 'user1@example.com');
+      }
+
+      if (token === TOKENS.user2) {
+        return sessionForUser(2, 'user2@example.com');
+      }
+
+      return null;
+    });
+
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    } else {
+      delete global.fetch;
+    }
+  });
+
+  describe('POST /api/v1/posts/refresh', () => {
+    it('refreshes feeds, creates new articles and posts, and returns a summary', async () => {
+      const feed = await prisma.feed.create({
+        data: {
+          ownerKey: '1',
+          url: 'https://example.com/feed.xml',
+          lastFetchedAt: new Date('2025-02-01T00:00:00Z'),
+        },
+      });
+
+      const publishedAt = new Date(Date.now() - 60 * 1000);
+      const rss = `<?xml version="1.0"?><rss version="2.0"><channel><title>Feed</title><item><title>Story</title><description>Snippet</description><pubDate>${publishedAt.toUTCString()}</pubDate><guid>guid-1</guid></item></channel></rss>`;
+
+      global.fetch = jest.fn(async () => ({
+        ok: true,
+        status: 200,
+        text: async () => rss,
+      }));
+
+      const response = await withAuth(
+        TOKENS.user1,
+        request(app).post('/api/v1/posts/refresh')
+      )
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      expect(global.fetch).toHaveBeenCalledWith(feed.url, expect.any(Object));
+      expect(response.body.data.feeds).toHaveLength(1);
+      expect(response.body.data.feeds[0]).toEqual(
+        expect.objectContaining({
+          feedId: feed.id,
+          articlesCreated: 1,
+          itemsWithinWindow: 1,
+          error: null,
+        })
+      );
+
+      const articles = await prisma.article.findMany();
+      const posts = await prisma.post.findMany();
+      expect(articles).toHaveLength(1);
+      expect(posts).toHaveLength(1);
+      expect(posts[0].content).toBe(postsService.POST_PLACEHOLDER_CONTENT);
+
+      const updatedFeed = await prisma.feed.findUnique({ where: { id: feed.id } });
+      expect(updatedFeed.lastFetchedAt).not.toBeNull();
+    });
+  });
+
+  describe('POST /api/v1/posts/cleanup', () => {
+    it('removes old articles and their posts for the authenticated user', async () => {
+      const now = new Date();
+      const feed = await prisma.feed.create({
+        data: {
+          ownerKey: '1',
+          url: 'https://example.com/cleanup.xml',
+        },
+      });
+
+      const staleArticle = await prisma.article.create({
+        data: {
+          feedId: feed.id,
+          title: 'Old',
+          contentSnippet: 'Old snippet',
+          publishedAt: new Date(now.getTime() - 9 * 24 * 60 * 60 * 1000),
+          guid: 'old-guid',
+          link: null,
+          dedupeKey: 'guid:old-guid',
+        },
+      });
+      await prisma.post.create({ data: { articleId: staleArticle.id, content: 'Old post' } });
+
+      const recentArticle = await prisma.article.create({
+        data: {
+          feedId: feed.id,
+          title: 'Recent',
+          contentSnippet: 'Recent snippet',
+          publishedAt: new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000),
+          guid: 'recent-guid',
+          link: null,
+          dedupeKey: 'guid:recent-guid',
+        },
+      });
+      await prisma.post.create({ data: { articleId: recentArticle.id, content: 'Recent post' } });
+
+      const response = await withAuth(
+        TOKENS.user1,
+        request(app).post('/api/v1/posts/cleanup')
+      )
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      expect(response.body.data).toEqual({ removedArticles: 1, removedPosts: 1 });
+
+      const remainingArticles = await prisma.article.findMany();
+      expect(remainingArticles).toHaveLength(1);
+      expect(remainingArticles[0].title).toBe('Recent');
+    });
+  });
+
+  describe('GET /api/v1/posts', () => {
+    it('lists recent posts with pagination metadata and includes post content', async () => {
+      const now = new Date();
+      const feed = await prisma.feed.create({
+        data: {
+          ownerKey: '1',
+          url: 'https://example.com/list.xml',
+        },
+      });
+
+      const rss = `<?xml version="1.0"?><rss version="2.0"><channel><title>Feed</title>${[0, 1, 2]
+        .map((daysAgo) => {
+          const date = new Date(now.getTime() - daysAgo * 24 * 60 * 60 * 1000);
+          return `<item><title>Item ${daysAgo}</title><description>Snippet ${daysAgo}</description><pubDate>${date.toUTCString()}</pubDate><guid>guid-${daysAgo}</guid></item>`;
+        })
+        .join('')}</channel></rss>`;
+
+      global.fetch = jest.fn(async () => ({
+        ok: true,
+        status: 200,
+        text: async () => rss,
+      }));
+
+      await postsService.refreshUserFeeds({ ownerKey: '1', now, fetcher: global.fetch });
+
+      const firstPage = await withAuth(
+        TOKENS.user1,
+        request(app).get('/api/v1/posts').query({ limit: 2 })
+      )
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      expect(firstPage.body.data.items).toHaveLength(2);
+      expect(firstPage.body.data.items[0]).toEqual(
+        expect.objectContaining({
+          title: 'Item 0',
+          post: expect.objectContaining({ content: postsService.POST_PLACEHOLDER_CONTENT }),
+        })
+      );
+      const cursor = firstPage.body.meta.nextCursor;
+      expect(cursor).not.toBeNull();
+
+      const secondPage = await withAuth(
+        TOKENS.user1,
+        request(app).get('/api/v1/posts').query({ cursor })
+      )
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      expect(secondPage.body.data.items).toHaveLength(1);
+      expect(secondPage.body.meta.nextCursor).toBeNull();
+    });
+  });
+});

--- a/backend/tests/posts.service.test.js
+++ b/backend/tests/posts.service.test.js
@@ -1,0 +1,352 @@
+const { refreshUserFeeds, cleanupOldArticles, listRecentArticles, InvalidCursorError, POST_PLACEHOLDER_CONTENT } = require('../src/services/posts.service');
+const { prisma } = require('../src/lib/prisma');
+
+const toRssDate = (date) => new Date(date).toUTCString();
+
+const buildRss = (items) => `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"><channel><title>Example</title>${items.join('')}</channel></rss>`;
+
+const makeRssItem = ({
+  title,
+  guid,
+  link,
+  description = 'Sample description',
+  publishedAt,
+}) => {
+  const parts = [`<title>${title}</title>`, `<description>${description}</description>`, `<pubDate>${toRssDate(publishedAt)}</pubDate>`];
+  if (guid !== undefined) {
+    parts.push(`<guid>${guid}</guid>`);
+  }
+  if (link !== undefined) {
+    parts.push(`<link>${link}</link>`);
+  }
+  return `<item>${parts.join('')}</item>`;
+};
+
+const createFetchMock = (responsesByUrl) =>
+  jest.fn(async (url) => {
+    if (!responsesByUrl.has(url)) {
+      throw new Error(`Unexpected URL requested: ${url}`);
+    }
+
+    const entry = responsesByUrl.get(url);
+
+    if (entry instanceof Error) {
+      throw entry;
+    }
+
+    if (entry && entry.reject) {
+      throw entry.reject;
+    }
+
+    const ok = entry?.ok ?? true;
+    const status = entry?.status ?? (ok ? 200 : 500);
+    const body = entry?.body ?? entry;
+
+    return {
+      ok,
+      status,
+      text: async () => body,
+    };
+  });
+
+const createFeed = async ({ ownerKey = '1', url = 'https://example.com/feed.xml', lastFetchedAt = null }) =>
+  prisma.feed.create({ data: { ownerKey, url, lastFetchedAt } });
+
+describe('posts.service', () => {
+  beforeEach(() => {
+    prisma.__reset();
+  });
+
+  describe('refreshUserFeeds', () => {
+    it('skips feeds that are still within the cooldown window', async () => {
+      const now = new Date('2025-03-01T12:00:00Z');
+      const recent = new Date(now.getTime() - 30 * 60 * 1000);
+      const feed = await createFeed({ lastFetchedAt: recent });
+      const fetcher = jest.fn();
+
+      const result = await refreshUserFeeds({ ownerKey: '1', now, fetcher });
+
+      expect(fetcher).not.toHaveBeenCalled();
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0]).toEqual(
+        expect.objectContaining({
+          feedId: feed.id,
+          skippedByCooldown: true,
+          articlesCreated: 0,
+        })
+      );
+
+      const updatedFeed = await prisma.feed.findUnique({ where: { id: feed.id } });
+      expect(updatedFeed.lastFetchedAt).toEqual(recent);
+    });
+
+    it('fetches feeds outside the cooldown window and updates lastFetchedAt', async () => {
+      const now = new Date('2025-03-01T12:00:00Z');
+      const feed = await createFeed({ lastFetchedAt: new Date('2025-02-28T00:00:00Z') });
+      const fetcher = createFetchMock(
+        new Map([[feed.url, buildRss([makeRssItem({ title: 'New', guid: 'guid-1', publishedAt: now })])]])
+      );
+
+      const result = await refreshUserFeeds({ ownerKey: '1', now, fetcher });
+
+      expect(fetcher).toHaveBeenCalledTimes(1);
+      expect(result.results[0]).toEqual(
+        expect.objectContaining({
+          feedId: feed.id,
+          skippedByCooldown: false,
+          articlesCreated: 1,
+          itemsWithinWindow: 1,
+        })
+      );
+
+      const updatedFeed = await prisma.feed.findUnique({ where: { id: feed.id } });
+      expect(updatedFeed.lastFetchedAt?.toISOString()).toBe(now.toISOString());
+    });
+
+    it('ignores items published outside the 7-day window', async () => {
+      const now = new Date('2025-03-08T12:00:00Z');
+      const feed = await createFeed({ lastFetchedAt: new Date('2025-02-20T00:00:00Z') });
+      const oldDate = new Date(now.getTime() - 8 * 24 * 60 * 60 * 1000);
+      const recentDate = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000);
+
+      const rss = buildRss([
+        makeRssItem({ title: 'Old', guid: 'g-old', publishedAt: oldDate }),
+        makeRssItem({ title: 'Recent', guid: 'g-recent', publishedAt: recentDate }),
+      ]);
+
+      const fetcher = createFetchMock(new Map([[feed.url, rss]]));
+
+      const summary = await refreshUserFeeds({ ownerKey: '1', now, fetcher });
+
+      expect(summary.results[0]).toEqual(
+        expect.objectContaining({
+          articlesCreated: 1,
+          itemsWithinWindow: 1,
+        })
+      );
+
+      const storedArticles = await prisma.article.findMany();
+      expect(storedArticles).toHaveLength(1);
+      expect(storedArticles[0].title).toBe('Recent');
+    });
+
+    it('is idempotent for items that provide guid values', async () => {
+      const now = new Date('2025-03-01T12:00:00Z');
+      const feed = await createFeed({ lastFetchedAt: new Date('2025-02-01T00:00:00Z') });
+      const rss = buildRss([makeRssItem({ title: 'Guid', guid: 'item-guid', publishedAt: now })]);
+      const fetcher = createFetchMock(new Map([[feed.url, rss]]));
+
+      const firstRun = await refreshUserFeeds({ ownerKey: '1', now, fetcher });
+      const secondRun = await refreshUserFeeds({ ownerKey: '1', now, fetcher });
+
+      expect(firstRun.results[0].articlesCreated).toBe(1);
+      expect(secondRun.results[0].articlesCreated).toBe(0);
+      const articles = await prisma.article.findMany();
+      const posts = await prisma.post.findMany();
+      expect(articles).toHaveLength(1);
+      expect(posts).toHaveLength(1);
+      expect(posts[0].content).toBe(POST_PLACEHOLDER_CONTENT);
+    });
+
+    it('is idempotent when guid is missing but link is provided', async () => {
+      const now = new Date('2025-03-01T13:00:00Z');
+      const feed = await createFeed({ url: 'https://example.com/link-feed.xml', lastFetchedAt: new Date('2025-02-01T00:00:00Z') });
+      const rss = buildRss([makeRssItem({ title: 'Link Item', link: 'https://news.example.com/item', publishedAt: now })]);
+      const fetcher = createFetchMock(new Map([[feed.url, rss]]));
+
+      await refreshUserFeeds({ ownerKey: '1', now, fetcher });
+      const secondRun = await refreshUserFeeds({ ownerKey: '1', now, fetcher });
+
+      const articles = await prisma.article.findMany();
+      const posts = await prisma.post.findMany();
+
+      expect(articles).toHaveLength(1);
+      expect(posts).toHaveLength(1);
+      expect(posts[0].content).toBe(POST_PLACEHOLDER_CONTENT);
+      expect(secondRun.results[0].articlesCreated).toBe(0);
+    });
+
+    it('derives a dedupe key when guid and link are missing', async () => {
+      const now = new Date('2025-03-02T10:00:00Z');
+      const feed = await createFeed({ url: 'https://example.com/derived.xml', lastFetchedAt: new Date('2025-02-01T00:00:00Z') });
+      const rss = buildRss([makeRssItem({ title: 'Derived Item', description: 'Content body', publishedAt: now })]);
+      const fetcher = createFetchMock(new Map([[feed.url, rss]]));
+
+      const firstRun = await refreshUserFeeds({ ownerKey: '1', now, fetcher });
+      const secondRun = await refreshUserFeeds({ ownerKey: '1', now, fetcher });
+
+      const articles = await prisma.article.findMany();
+      const posts = await prisma.post.findMany();
+
+      expect(firstRun.results[0].articlesCreated).toBe(1);
+      expect(secondRun.results[0].articlesCreated).toBe(0);
+      expect(articles).toHaveLength(1);
+      expect(posts).toHaveLength(1);
+      expect(posts[0].content).toBe(POST_PLACEHOLDER_CONTENT);
+    });
+
+    it('continues processing other feeds when a fetch fails', async () => {
+      const now = new Date('2025-03-03T09:00:00Z');
+      const feedA = await createFeed({ url: 'https://example.com/fail.xml', lastFetchedAt: new Date('2025-02-01T00:00:00Z') });
+      const feedB = await createFeed({ url: 'https://example.com/ok.xml', lastFetchedAt: new Date('2025-02-01T00:00:00Z') });
+
+      const rss = buildRss([makeRssItem({ title: 'Success', guid: 'ok-1', publishedAt: now })]);
+      const fetcher = createFetchMock(
+        new Map([
+          [feedA.url, { reject: new Error('Network failure') }],
+          [feedB.url, rss],
+        ])
+      );
+
+      const result = await refreshUserFeeds({ ownerKey: '1', now, fetcher });
+
+      const summaryByFeed = new Map(result.results.map((entry) => [entry.feedId, entry]));
+
+      expect(summaryByFeed.get(feedA.id).error).toEqual({ message: 'Network failure' });
+      expect(summaryByFeed.get(feedA.id).articlesCreated).toBe(0);
+
+      expect(summaryByFeed.get(feedB.id).error).toBeNull();
+      expect(summaryByFeed.get(feedB.id).articlesCreated).toBe(1);
+
+      const articles = await prisma.article.findMany();
+      expect(articles).toHaveLength(1);
+      expect(articles[0].title).toBe('Success');
+    });
+
+    it('counts invalid items that cannot be normalized', async () => {
+      const now = new Date('2025-03-04T12:00:00Z');
+      const feed = await createFeed({ lastFetchedAt: new Date('2025-02-01T00:00:00Z') });
+      const invalidRss = `<?xml version="1.0"?><rss version="2.0"><channel><title>Invalid</title><item><title>Missing Date</title></item></channel></rss>`;
+      const fetcher = createFetchMock(new Map([[feed.url, invalidRss]]));
+
+      const result = await refreshUserFeeds({ ownerKey: '1', now, fetcher });
+
+      expect(result.results[0].invalidItems).toBe(1);
+      expect(result.results[0].articlesCreated).toBe(0);
+
+      const articles = await prisma.article.findMany();
+      expect(articles).toHaveLength(0);
+    });
+  });
+
+  describe('cleanupOldArticles', () => {
+    it('removes articles older than seven days along with their posts', async () => {
+      const now = new Date('2025-03-10T09:00:00Z');
+      const feed = await createFeed({ lastFetchedAt: new Date('2025-02-01T00:00:00Z') });
+
+      const oldArticle = await prisma.article.create({
+        data: {
+          feedId: feed.id,
+          title: 'Old',
+          contentSnippet: 'Old content',
+          publishedAt: new Date(now.getTime() - 9 * 24 * 60 * 60 * 1000),
+          guid: 'old-guid',
+          link: null,
+          dedupeKey: 'guid:old-guid',
+        },
+      });
+      await prisma.post.create({ data: { articleId: oldArticle.id, content: 'Old post' } });
+
+      const recentArticle = await prisma.article.create({
+        data: {
+          feedId: feed.id,
+          title: 'Recent',
+          contentSnippet: 'Recent content',
+          publishedAt: new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000),
+          guid: 'recent-guid',
+          link: null,
+          dedupeKey: 'guid:recent-guid',
+        },
+      });
+      await prisma.post.create({ data: { articleId: recentArticle.id, content: 'Recent post' } });
+
+      const outcome = await cleanupOldArticles({ ownerKey: '1', now });
+
+      expect(outcome).toEqual({ removedArticles: 1, removedPosts: 1 });
+
+      const remainingArticles = await prisma.article.findMany();
+      expect(remainingArticles).toHaveLength(1);
+      expect(remainingArticles[0].title).toBe('Recent');
+
+      const remainingPosts = await prisma.post.findMany();
+      expect(remainingPosts).toHaveLength(1);
+      expect(remainingPosts[0].content).toBe('Recent post');
+    });
+  });
+
+  describe('listRecentArticles', () => {
+    it('returns recent articles ordered by publishedAt desc with pagination', async () => {
+      const now = new Date('2025-03-05T12:00:00Z');
+      const feed = await createFeed({ lastFetchedAt: new Date('2025-02-01T00:00:00Z') });
+
+      const rss = buildRss([
+        makeRssItem({ title: 'First', guid: 'a', publishedAt: new Date(now.getTime() - 1 * 24 * 60 * 60 * 1000) }),
+        makeRssItem({ title: 'Second', guid: 'b', publishedAt: new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000) }),
+        makeRssItem({ title: 'Third', guid: 'c', publishedAt: new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000) }),
+      ]);
+      const fetcher = createFetchMock(new Map([[feed.url, rss]]));
+
+      await refreshUserFeeds({ ownerKey: '1', now, fetcher });
+
+      const firstPage = await listRecentArticles({ ownerKey: '1', limit: 2, now });
+      expect(firstPage.items).toHaveLength(2);
+      expect(firstPage.items[0].title).toBe('First');
+      expect(firstPage.items[1].title).toBe('Second');
+      expect(firstPage.nextCursor).not.toBeNull();
+
+      const secondPage = await listRecentArticles({ ownerKey: '1', cursor: firstPage.nextCursor, now });
+      expect(secondPage.items).toHaveLength(1);
+      expect(secondPage.items[0].title).toBe('Third');
+      expect(secondPage.nextCursor).toBeNull();
+
+      const posts = await prisma.post.findMany();
+      expect(posts).toHaveLength(3);
+      posts.forEach((post) => {
+        expect(post.content).toBe(POST_PLACEHOLDER_CONTENT);
+      });
+    });
+
+    it('filters out articles older than seven days and supports feed filtering', async () => {
+      const now = new Date('2025-03-06T12:00:00Z');
+      const feedA = await createFeed({ url: 'https://example.com/a.xml', lastFetchedAt: new Date('2025-02-01T00:00:00Z') });
+      const feedB = await createFeed({ url: 'https://example.com/b.xml', lastFetchedAt: new Date('2025-02-01T00:00:00Z') });
+
+      await prisma.article.create({
+        data: {
+          feedId: feedA.id,
+          title: 'Too Old',
+          contentSnippet: 'Old snippet',
+          publishedAt: new Date(now.getTime() - 10 * 24 * 60 * 60 * 1000),
+          guid: 'too-old',
+          link: null,
+          dedupeKey: 'guid:too-old',
+        },
+      });
+
+      const rssA = buildRss([makeRssItem({ title: 'Fresh A', guid: 'fresh-a', publishedAt: now })]);
+      const rssB = buildRss([makeRssItem({ title: 'Fresh B', guid: 'fresh-b', publishedAt: new Date(now.getTime() - 2 * 60 * 60 * 1000) })]);
+      const fetcher = createFetchMock(
+        new Map([
+          [feedA.url, rssA],
+          [feedB.url, rssB],
+        ])
+      );
+
+      await refreshUserFeeds({ ownerKey: '1', now, fetcher });
+
+      const listAll = await listRecentArticles({ ownerKey: '1', now });
+      expect(listAll.items.map((item) => item.title)).toEqual(['Fresh A', 'Fresh B']);
+
+      const listOnlyB = await listRecentArticles({ ownerKey: '1', feedId: feedB.id, now });
+      expect(listOnlyB.items).toHaveLength(1);
+      expect(listOnlyB.items[0].title).toBe('Fresh B');
+    });
+
+    it('throws an InvalidCursorError when the cursor cannot be decoded', async () => {
+      const now = new Date('2025-03-07T12:00:00Z');
+      await createFeed({ lastFetchedAt: new Date('2025-02-01T00:00:00Z') });
+
+      await expect(listRecentArticles({ ownerKey: '1', cursor: 'not-base64', now })).rejects.toBeInstanceOf(InvalidCursorError);
+    });
+  });
+});

--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -4,30 +4,305 @@ process.env.ENABLE_METRICS = process.env.ENABLE_METRICS || 'false';
 
 jest.mock('../src/lib/prisma', () => {
   const feeds = [];
-  let idCounter = 1;
+  const articles = [];
+  const posts = [];
 
-  const clone = (entity) => ({ ...entity });
+  let feedIdCounter = 1;
+  let articleIdCounter = 1;
+  let postIdCounter = 1;
 
-  const filterFeeds = (where = {}) => {
-    let result = feeds.slice();
-
-    if (where.ownerKey) {
-      result = result.filter((feed) => feed.ownerKey === where.ownerKey);
+  const clone = (entity) => {
+    if (entity == null) {
+      return entity;
     }
 
-    if (where.id != null) {
-      result = result.filter((feed) => feed.id === where.id);
+    const copy = { ...entity };
+    Object.keys(copy).forEach((key) => {
+      if (copy[key] instanceof Date) {
+        copy[key] = new Date(copy[key].getTime());
+      }
+    });
+    return copy;
+  };
+
+  const matchesScalar = (actual, condition) => {
+    if (condition == null) {
+      return true;
+    }
+
+    if (typeof condition === 'object' && condition !== null) {
+      if (Array.isArray(condition.in)) {
+        return condition.in.includes(actual);
+      }
+
+      if (condition.equals !== undefined) {
+        return actual === condition.equals;
+      }
+
+      if (condition.not !== undefined) {
+        return !matchesScalar(actual, condition.not);
+      }
+    }
+
+    return actual === condition;
+  };
+
+  const toDate = (value) => {
+    if (value instanceof Date) {
+      return value;
+    }
+    return new Date(value);
+  };
+
+  const matchDateCondition = (actual, condition) => {
+    if (!(actual instanceof Date)) {
+      actual = new Date(actual);
+    }
+
+    if (Number.isNaN(actual.getTime())) {
+      return false;
+    }
+
+    if (condition == null) {
+      return true;
+    }
+
+    if (condition instanceof Date || typeof condition === 'string' || typeof condition === 'number') {
+      const target = toDate(condition);
+      return actual.getTime() === target.getTime();
+    }
+
+    if (typeof condition === 'object') {
+      if (condition.lt !== undefined && !(actual.getTime() < toDate(condition.lt).getTime())) {
+        return false;
+      }
+      if (condition.lte !== undefined && !(actual.getTime() <= toDate(condition.lte).getTime())) {
+        return false;
+      }
+      if (condition.gt !== undefined && !(actual.getTime() > toDate(condition.gt).getTime())) {
+        return false;
+      }
+      if (condition.gte !== undefined && !(actual.getTime() >= toDate(condition.gte).getTime())) {
+        return false;
+      }
+      if (condition.equals !== undefined && !matchDateCondition(actual, condition.equals)) {
+        return false;
+      }
+    }
+
+    return true;
+  };
+
+  const matchFeedWhere = (feed, where = {}) => {
+    if (where == null) {
+      return true;
+    }
+
+    if (!matchesScalar(feed.id, where.id)) {
+      return false;
+    }
+
+    if (where.ownerKey !== undefined && feed.ownerKey !== where.ownerKey) {
+      return false;
     }
 
     if (where.url) {
       if (Array.isArray(where.url.in)) {
-        result = result.filter((feed) => where.url.in.includes(feed.url));
-      } else if (typeof where.url === 'string') {
-        result = result.filter((feed) => feed.url === where.url);
+        if (!where.url.in.includes(feed.url)) {
+          return false;
+        }
+      } else if (typeof where.url === 'string' && feed.url !== where.url) {
+        return false;
+      }
+    }
+
+    return true;
+  };
+
+  const filterFeeds = (where = {}) => feeds.filter((feed) => matchFeedWhere(feed, where));
+
+  const matchArticleWhere = (article, where = {}) => {
+    if (where == null) {
+      return true;
+    }
+
+    if (!matchesScalar(article.id, where.id)) {
+      return false;
+    }
+
+    if (!matchesScalar(article.feedId, where.feedId)) {
+      return false;
+    }
+
+    if (where.dedupeKey !== undefined && article.dedupeKey !== where.dedupeKey) {
+      return false;
+    }
+
+    if (where.guid !== undefined) {
+      if (where.guid === null) {
+        if (article.guid !== null) {
+          return false;
+        }
+      } else if (article.guid !== where.guid) {
+        return false;
+      }
+    }
+
+    if (where.link !== undefined) {
+      if (where.link === null) {
+        if (article.link !== null) {
+          return false;
+        }
+      } else if (article.link !== where.link) {
+        return false;
+      }
+    }
+
+    if (where.publishedAt !== undefined && !matchDateCondition(article.publishedAt, where.publishedAt)) {
+      return false;
+    }
+
+    if (where.feed && !matchFeedWhere(feeds.find((feed) => feed.id === article.feedId) ?? {}, where.feed)) {
+      return false;
+    }
+
+    if (Array.isArray(where.AND)) {
+      if (!where.AND.every((condition) => matchArticleWhere(article, condition))) {
+        return false;
+      }
+    }
+
+    if (Array.isArray(where.OR)) {
+      if (!where.OR.some((condition) => matchArticleWhere(article, condition))) {
+        return false;
+      }
+    }
+
+    return true;
+  };
+
+  const filterArticles = (where = {}) => articles.filter((article) => matchArticleWhere(article, where));
+
+  const matchPostWhere = (post, where = {}) => {
+    if (where == null) {
+      return true;
+    }
+
+    if (!matchesScalar(post.id, where.id)) {
+      return false;
+    }
+
+    if (!matchesScalar(post.articleId, where.articleId)) {
+      return false;
+    }
+
+    return true;
+  };
+
+  const filterPosts = (where = {}) => posts.filter((post) => matchPostWhere(post, where));
+
+  const orderByComparator = (orderBy) => {
+    const fields = Array.isArray(orderBy) ? orderBy : [orderBy];
+    return (a, b) => {
+      for (const entry of fields) {
+        const [field, direction] = Object.entries(entry)[0];
+        const multiplier = direction === 'desc' ? -1 : 1;
+
+        let aValue = a[field];
+        let bValue = b[field];
+
+        if (aValue instanceof Date) {
+          aValue = aValue.getTime();
+        }
+        if (bValue instanceof Date) {
+          bValue = bValue.getTime();
+        }
+
+        if (aValue < bValue) {
+          return -1 * multiplier;
+        }
+        if (aValue > bValue) {
+          return 1 * multiplier;
+        }
+      }
+      return 0;
+    };
+  };
+
+  const selectFields = (record, select) => {
+    if (!select || typeof select !== 'object') {
+      return clone(record);
+    }
+
+    const result = {};
+    Object.keys(select).forEach((key) => {
+      if (!select[key]) {
+        return;
+      }
+
+      const value = record[key];
+      if (value instanceof Date) {
+        result[key] = new Date(value.getTime());
+        return;
+      }
+
+      if (Array.isArray(value)) {
+        result[key] = value.map((item) => (item && typeof item === 'object' ? clone(item) : item));
+        return;
+      }
+
+      if (value && typeof value === 'object') {
+        result[key] = clone(value);
+        return;
+      }
+
+      result[key] = value;
+    });
+
+    return result;
+  };
+
+  const includeRelations = (article, include) => {
+    if (!include) {
+      return clone(article);
+    }
+
+    const result = clone(article);
+
+    if (include.post) {
+      const post = posts.find((entry) => entry.articleId === article.id) || null;
+      if (post) {
+        if (include.post.select) {
+          result.post = selectFields(post, include.post.select);
+        } else {
+          result.post = clone(post);
+        }
+      } else {
+        result.post = null;
+      }
+    }
+
+    if (include.feed) {
+      const feed = feeds.find((entry) => entry.id === article.feedId) || null;
+      if (feed) {
+        if (include.feed.select) {
+          result.feed = selectFields(feed, include.feed.select);
+        } else {
+          result.feed = clone(feed);
+        }
+      } else {
+        result.feed = null;
       }
     }
 
     return result;
+  };
+
+  const uniqueConstraintError = (target) => {
+    const error = new Error(`Unique constraint failed on the fields: (${target})`);
+    error.code = 'P2002';
+    error.meta = { target };
+    return error;
   };
 
   const prisma = {
@@ -35,8 +310,8 @@ jest.mock('../src/lib/prisma', () => {
       findMany: async ({ where = {}, orderBy, take, skip, cursor } = {}) => {
         let result = filterFeeds(where);
 
-        if (orderBy?.id === 'asc') {
-          result = result.slice().sort((a, b) => a.id - b.id);
+        if (orderBy) {
+          result = result.slice().sort(orderByComparator(orderBy));
         }
 
         if (cursor?.id != null) {
@@ -56,24 +331,26 @@ jest.mock('../src/lib/prisma', () => {
         return result.map(clone);
       },
       count: async ({ where = {} } = {}) => filterFeeds(where).length,
-      findUnique: async ({ where }) => {
+      findUnique: async ({ where, select }) => {
+        let found = null;
+
         if (where.id != null) {
-          const found = feeds.find((feed) => feed.id === where.id);
-          return found ? clone(found) : null;
-        }
-
-        if (where.ownerKey_url) {
+          found = feeds.find((feed) => feed.id === where.id) || null;
+        } else if (where.ownerKey_url) {
           const { ownerKey, url } = where.ownerKey_url;
-          const found = feeds.find((feed) => feed.ownerKey === ownerKey && feed.url === url);
-          return found ? clone(found) : null;
+          found = feeds.find((feed) => feed.ownerKey === ownerKey && feed.url === url) || null;
         }
 
-        return null;
+        if (!found) {
+          return null;
+        }
+
+        return select ? selectFields(found, select) : clone(found);
       },
       create: async ({ data }) => {
         const now = new Date();
         const record = {
-          id: idCounter++,
+          id: feedIdCounter++,
           ownerKey: data.ownerKey,
           url: data.url,
           title: data.title ?? null,
@@ -110,7 +387,165 @@ jest.mock('../src/lib/prisma', () => {
         }
 
         const [removed] = feeds.splice(index, 1);
+        const removedArticleIds = articles.filter((article) => article.feedId === removed.id).map((article) => article.id);
+
+        for (let i = articles.length - 1; i >= 0; i -= 1) {
+          if (articles[i].feedId === removed.id) {
+            articles.splice(i, 1);
+          }
+        }
+
+        for (let i = posts.length - 1; i >= 0; i -= 1) {
+          if (removedArticleIds.includes(posts[i].articleId)) {
+            posts.splice(i, 1);
+          }
+        }
+
         return clone(removed);
+      },
+    },
+    article: {
+      findMany: async ({ where = {}, orderBy, take, skip, cursor, include, select } = {}) => {
+        let result = filterArticles(where);
+
+        if (orderBy) {
+          result = result.slice().sort(orderByComparator(orderBy));
+        }
+
+        if (cursor?.id != null) {
+          const index = result.findIndex((article) => article.id === cursor.id);
+          if (index === -1) {
+            result = [];
+          } else {
+            const skipCount = typeof skip === 'number' ? skip : 0;
+            result = result.slice(index + skipCount);
+          }
+        }
+
+        if (typeof take === 'number') {
+          result = take >= 0 ? result.slice(0, take) : [];
+        }
+
+        if (select) {
+          return result.map((item) => selectFields(item, select));
+        }
+
+        if (include) {
+          return result.map((item) => includeRelations(item, include));
+        }
+
+        return result.map(clone);
+      },
+      findUnique: async ({ where, select }) => {
+        let found = null;
+
+        if (where.id != null) {
+          found = articles.find((article) => article.id === where.id) || null;
+        } else if (where.feedId_dedupeKey) {
+          const { feedId, dedupeKey } = where.feedId_dedupeKey;
+          found = articles.find((article) => article.feedId === feedId && article.dedupeKey === dedupeKey) || null;
+        } else if (where.feedId_guid) {
+          const { feedId, guid } = where.feedId_guid;
+          found = articles.find((article) => article.feedId === feedId && article.guid === guid) || null;
+        } else if (where.feedId_link) {
+          const { feedId, link } = where.feedId_link;
+          found = articles.find((article) => article.feedId === feedId && article.link === link) || null;
+        }
+
+        if (!found) {
+          return null;
+        }
+
+        return select ? selectFields(found, select) : clone(found);
+      },
+      create: async ({ data }) => {
+        if (data.guid != null) {
+          const duplicateGuid = articles.some((article) => article.feedId === data.feedId && article.guid === data.guid);
+          if (duplicateGuid) {
+            throw uniqueConstraintError('Article_feedId_guid_key');
+          }
+        }
+
+        if (data.link != null) {
+          const duplicateLink = articles.some((article) => article.feedId === data.feedId && article.link === data.link);
+          if (duplicateLink) {
+            throw uniqueConstraintError('Article_feedId_link_key');
+          }
+        }
+
+        const duplicateKey = articles.some((article) => article.feedId === data.feedId && article.dedupeKey === data.dedupeKey);
+        if (duplicateKey) {
+          throw uniqueConstraintError('Article_feedId_dedupeKey_key');
+        }
+
+        const now = new Date();
+        const record = {
+          id: articleIdCounter++,
+          feedId: data.feedId,
+          title: data.title,
+          contentSnippet: data.contentSnippet,
+          publishedAt: new Date(data.publishedAt),
+          guid: data.guid ?? null,
+          link: data.link ?? null,
+          dedupeKey: data.dedupeKey,
+          createdAt: now,
+          updatedAt: now,
+        };
+
+        articles.push(record);
+
+        return clone(record);
+      },
+      deleteMany: async ({ where = {} }) => {
+        const matching = filterArticles(where);
+        const ids = new Set(matching.map((article) => article.id));
+
+        for (let i = articles.length - 1; i >= 0; i -= 1) {
+          if (ids.has(articles[i].id)) {
+            articles.splice(i, 1);
+          }
+        }
+
+        for (let i = posts.length - 1; i >= 0; i -= 1) {
+          if (ids.has(posts[i].articleId)) {
+            posts.splice(i, 1);
+          }
+        }
+
+        return { count: matching.length };
+      },
+    },
+    post: {
+      create: async ({ data }) => {
+        const duplicate = posts.some((post) => post.articleId === data.articleId);
+        if (duplicate) {
+          throw uniqueConstraintError('Post_articleId_key');
+        }
+
+        const now = new Date();
+        const record = {
+          id: postIdCounter++,
+          articleId: data.articleId,
+          content: data.content,
+          createdAt: now,
+        };
+
+        posts.push(record);
+
+        return clone(record);
+      },
+      findMany: async ({ where = {} } = {}) => filterPosts(where).map(clone),
+      deleteMany: async ({ where = {} }) => {
+        const matching = filterPosts(where);
+        const ids = new Set(matching.map((post) => post.id));
+
+        for (let i = posts.length - 1; i >= 0; i -= 1) {
+          if (ids.has(posts[i].id)) {
+            posts.splice(i, 1);
+          }
+        }
+
+        return { count: matching.length };
       },
     },
     helloMessage: {
@@ -118,7 +553,11 @@ jest.mock('../src/lib/prisma', () => {
     },
     __reset: () => {
       feeds.splice(0, feeds.length);
-      idCounter = 1;
+      articles.splice(0, articles.length);
+      posts.splice(0, posts.length);
+      feedIdCounter = 1;
+      articleIdCounter = 1;
+      postIdCounter = 1;
     },
   };
 


### PR DESCRIPTION
## Summary
- add a posts service that refreshes RSS feeds, cleans up old content, and lists recent posts with pagination
- expose POST /api/v1/posts/refresh, POST /api/v1/posts/cleanup, and GET /api/v1/posts endpoints plus documentation updates
- extend the Prisma test harness and add domain/API tests covering cooldowns, dedupe, cleanup, and listing flows

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0292be05883259388efab9b323ffd