### PR TITLE
docs: update OpenAPI specification and onboarding guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,86 +1,104 @@
-﻿# lkdposts
+# lkdposts
 
 Automação de posts para LinkedIn a partir de feeds RSS.
 
-## Estrutura do repositório
-- `backend/`: API Express com middlewares de segurança, observabilidade básica e respostas padronizadas.
-- `frontend/`: SPA React + Vite + Tailwind, consumindo o endpoint `/api/v1/hello` via TanStack Query.
+## Visão geral
+O lkdposts permite que cada usuário cadastre seus próprios feeds RSS, colete notícias recentes e gere posts prontos para revisão antes da publicação no LinkedIn. O backend aplica normalização, deduplicação e janelas de retenção, enquanto o frontend oferece uma interface simples para gerenciar feeds e visualizar posts gerados.
 
-## Requisitos
-- Node.js **20.19.0** ou superior
-- npm 10+
+## Arquitetura
+- **Backend**: Node.js + Express com Prisma, PostgreSQL (Neon) e observabilidade via Sentry. A API expõe rotas autenticadas em `/api/v1` usando envelopes JSON padronizados.
+- **Frontend**: React (Vite) com Tailwind CSS, TanStack Query e i18next para internacionalização.
+- **Deploy**: Aplicação hospedada na Vercel, utilizando funções serverless para o backend e banco PostgreSQL gerenciado no Neon.
 
-## Configuração rápida
-```bash
-# Backend
-cd backend
-cp .env.example .env          # ajuste CORS e porta se necessário
-npm install
-npm run dev                   # servidor em http://localhost:3001
+## Pré-requisitos
+- Node.js 20.19.0 LTS (compatível com `>=18.20.0`).
+- npm 10 ou superior.
+- Conta na **Vercel** para deploy do frontend + backend.
+- Conta na **Neon** (ou PostgreSQL compatível com TLS) para o banco de dados.
+- Projeto no **Google Cloud** com OAuth 2.0 habilitado para autenticação via Google.
 
-# Frontend
-cd ../frontend
-cp .env.example .env          # ajuste VITE_API_URL se necessário
-npm install
-npm run dev                   # aplicação em http://localhost:5173
-```
-
-A interface consome o backend usando `VITE_API_URL` (padrão `http://localhost:3001`) e exibe a mensagem retornada.
-
-## Back-end em detalhes
-- **Segurança**: Helmet, CORS restrito, HPP, xss-clean, rate limiting e limite de payload.
-- **Configuração**: variáveis de ambiente validadas com Zod (`backend/.env.example`).
-- **Observabilidade**: métricas Prometheus opcionais (`/metrics`) e health checks (`/health/live` e `/health/ready`).
-- **Documentação**: OpenAPI 3.1 gerada em `backend/docs/openapi.json` e disponível em `/docs`.
-- **Respostas**: envelope JSON único com `success`, `data` e `meta.requestId`.
-
-### Scripts úteis (`backend/package.json`)
-- `npm run dev` – nodemon com recarregamento
-- `npm run start` – execução em produção
-- `npm run lint` – ESLint em `src/**/*.js`
-- `npm test` – Jest + Supertest (smoke tests)
-- `npm run build` – lint + test (gate local)
-- `npm run docs:generate` – gera `docs/openapi.json`
-- `npm run task -- <dev|test|build|docs>` – wrapper utilitário
-
-## Front-end em detalhes
-- Estrutura enxuta em TypeScript com React Router, TanStack Query e Tailwind tokens.
-- Hooks locais + Query Client atendem às necessidades de estado para uma aplicação pequena.
-- i18n configurado com i18next para `pt-BR` e `en`.
-- Layout básico (`MainLayout`), navegação acessível e tema claro/escuro controlado no cliente.
-
-### Scripts úteis (`frontend/package.json`)
-- `npm run dev` – Vite com HMR
-- `npm run build` – `tsc --noEmit` + build de produção
-- `npm run preview` – serve o build gerado
-- `npm run lint` – ESLint para `src/**/*.ts(x)`
-- `npm test` – Vitest + Testing Library
-- `npm run type-check`, `npm run format`, `npm run ci`
-
-## CI
-- `.github/workflows/backend-ci.yml`: lint → test → audit → build + OpenAPI como artefato.
-- `.github/workflows/frontend-ci.yml`: lint → type-check → test → build com artefato do bundle.
-- **Branch protection**: configure apenas os checks obrigatórios `backend-ci / build-test` e `frontend-ci / quality`; evite checks extras de lint bloqueando merge.
-- **SonarCloud**: se surgirem comentários duplicados no PR, desative "Pull Request decoration" em SonarCloud (Project Settings -> General Settings -> Pull Request Decoration) ou mantenha apenas essa decoração sem outros bots.
-
-## Documentação adicional
-- `backend/docs/endpoints.md`: visão rápida dos endpoints expostos.
-## Autenticacao e autorizacao
-- Login exclusivo via Google. Apenas emails presentes na allowlist conseguem iniciar sessao.
-- O primeiro acesso ja garante que `rafrcruz@gmail.com` seja administrador fixo.
-- Usuarios autenticados recebem uma sessao assinada via cookie; todas as rotas `/api/v1` exigem essa sessao.
-- Administradores acessam a pagina `/allowlist` no frontend para cadastrar, alterar papel ou remover emails.
-
-## Variaveis de ambiente relevantes
+## Configuração
 ### Backend
-- `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`
-- `SESSION_SECRET`, `SESSION_TTL_SECONDS`, `SESSION_RENEW_THRESHOLD_SECONDS`
-- `SUPERADMIN_EMAIL`
-- `SENTRY_DSN_BACKEND`
+1. `cd backend`.
+2. `cp .env.example .env` e ajuste as variáveis conforme a necessidade.
+3. Instale dependências: `npm install`.
+4. Gere e aplique migrações no ambiente local: `npm run db:migrate:dev`.
+
+#### Variáveis obrigatórias (`backend/.env`)
+| Variável | Descrição |
+| --- | --- |
+| `DATABASE_URL` | URL do PostgreSQL (Neon) com `sslmode=require` e usuário com permissão de leitura/escrita. |
+| `GOOGLE_CLIENT_ID` | Client ID do app OAuth 2.0 configurado no Google. |
+| `GOOGLE_CLIENT_SECRET` | Client secret correspondente ao client ID acima. |
+| `GOOGLE_REDIRECT_URI` | URL de callback utilizada pelo backend (ex.: `http://localhost:3001/auth/callback/google`). |
+| `SESSION_SECRET` | Chave aleatória (mínimo 16 caracteres) usada para assinar cookies de sessão. |
+| `SUPERADMIN_EMAIL` | E-mail que receberá permissão de administrador no primeiro acesso. |
+
+#### Variáveis opcionais importantes
+| Variável | Valor padrão | Descrição |
+| --- | --- | --- |
+| `NODE_ENV` | `development` | Ambiente de execução. |
+| `HOST` / `PORT` | `0.0.0.0` / `3001` | Interface e porta HTTP do servidor Express. |
+| `CORS_ALLOWED_ORIGINS` | `http://localhost:5173` | Lista de origens permitidas para o frontend. |
+| `PAYLOAD_LIMIT` | `100kb` | Limite de tamanho do corpo das requisições. |
+| `RATE_LIMIT_WINDOW_MS` / `RATE_LIMIT_MAX` | `60000` / `100` | Janela e quantidade máxima de requisições por IP. |
+| `ENABLE_METRICS` | `true` | Habilita endpoint `/metrics` (Prometheus). |
+| `CACHE_MAX_AGE_SECONDS` | `60` | Tempo padrão de cache HTTP para respostas públicas. |
+| `SWAGGER_UI_ENABLED` | `true` | Exibe Swagger UI em `/docs`.
+| `DEBUG_AUTH` | `false` | Ativa logs extras de autenticação. |
+| `SESSION_TTL_SECONDS` | `3600` | Duração da sessão autenticada em segundos. |
+| `SESSION_RENEW_THRESHOLD_SECONDS` | `900` | Janela para renovação antecipada da sessão. |
+| `SENTRY_DSN_BACKEND` | vazio | DSN do Sentry para o backend. |
+| `PRISMA_URL` | vazio | URL alternativa com pool (ex.: Neon connection pooling). |
 
 ### Frontend
-- `VITE_API_URL`
-- `VITE_GOOGLE_CLIENT_ID`
-- `VITE_SENTRY_DSN_FRONTEND`
+1. `cd frontend`.
+2. `cp .env.example .env` e preencha as variáveis necessárias.
+3. Instale dependências: `npm install`.
 
-Configure `.env` e `.env.example` conforme os exemplos fornecidos para habilitar login e observabilidade.
+#### Variáveis (`frontend/.env`)
+| Variável | Obrigatória? | Descrição |
+| --- | --- | --- |
+| `VITE_API_URL` | Sim | URL do backend (ex.: `http://localhost:3001`). |
+| `VITE_GOOGLE_CLIENT_ID` | Sim | Client ID do Google usado para o fluxo OAuth no navegador. |
+| `VITE_DEFAULT_LOCALE` | Opcional | Locale padrão da UI (`pt-BR` por padrão). |
+| `VITE_FALLBACK_LOCALE` | Opcional | Locale de fallback (`en`). |
+| `VITE_SENTRY_DSN_FRONTEND` | Opcional | DSN do Sentry para monitoramento do frontend. |
+
+## Rodando localmente
+Abra dois terminais e execute:
+
+```bash
+# Terminal 1 - API
+npm run dev --prefix backend
+
+# Terminal 2 - Frontend
+npm run dev --prefix frontend
+```
+
+- Backend: http://localhost:3001 (Swagger UI em http://localhost:3001/docs quando `SWAGGER_UI_ENABLED=true`).
+- Frontend: http://localhost:5173 (consome o backend definido em `VITE_API_URL`).
+
+## Rodando em produção (Vercel + Neon)
+1. Crie um banco PostgreSQL no Neon e copie a `DATABASE_URL` (habilite connection pooling caso queira usar `PRISMA_URL`).
+2. Configure um projeto na Vercel apontando para este repositório. A Vercel utilizará o runtime Node.js 20 definido em `vercel.json`.
+3. Defina todas as variáveis de ambiente nas seções **Production** e **Preview** da Vercel:
+   - Variáveis do backend começam com os mesmos nomes utilizados em `backend/.env`.
+   - Variáveis do frontend começam com `VITE_` e precisam ser configuradas na aba "Environment Variables" do projeto Vercel para que o build do Vite as injete.
+4. Ajuste `VITE_API_URL` para apontar para o domínio público do deploy (ex.: `https://seu-projeto.vercel.app/api`).
+5. Rode as migrações em produção:
+   - Localmente, exporte as variáveis de produção e execute `npm run db:migrate:deploy` dentro de `backend/`; **ou**
+   - Utilize um job/Action apontando para o script `npm run db:migrate:deploy:vercel`, pensado para o ambiente serverless da Vercel.
+6. Dispare o deploy. A Vercel construirá o frontend e exporá o backend em `/api` utilizando o adaptador de Express definido em `api/index.js`.
+
+## Testes
+- **Backend (Jest + Supertest)**: `npm test --prefix backend`
+- **Frontend (Vitest + Testing Library)**: `npm test --prefix frontend`
+
+Tests adicionais (lint, type-check) podem ser executados com `npm run lint --prefix backend`, `npm run lint --prefix frontend` e `npm run type-check --prefix frontend` conforme necessário.
+
+## APIs e documentação
+- Swagger UI: `http://localhost:3001/docs`
+- Especificação OpenAPI 3.1 gerada automaticamente em `backend/docs/openapi.json` (`npm run docs:generate --prefix backend`).
+
+Com o README e a especificação OpenAPI atualizados, um novo desenvolvedor consegue provisionar o banco no Neon, configurar credenciais Google, rodar a aplicação localmente e publicar na Vercel sem passos adicionais.

--- a/backend/docs/openapi.json
+++ b/backend/docs/openapi.json
@@ -4,7 +4,7 @@
     "title": "lkdposts API",
     "version": "1.0.0",
     "description": "API responsável por disponibilizar funcionalidades de automação de posts.",
-    "x-generated-at": "2025-09-19T13:47:25.136Z",
+    "x-generated-at": "2025-09-21T23:48:19.877Z",
     "x-environment": "development"
   },
   "servers": [
@@ -23,14 +23,18 @@
             "example": true
           },
           "data": {
-            "type": "object"
+            "type": [
+              "object",
+              "null"
+            ]
           },
           "meta": {
             "type": "object",
             "properties": {
               "requestId": {
                 "type": "string",
-                "format": "uuid"
+                "format": "uuid",
+                "example": "00000000-0000-4000-8000-000000000000"
               }
             }
           }
@@ -55,7 +59,11 @@
                 "example": "Internal server error"
               },
               "details": {
-                "type": "object"
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "example": null
               }
             }
           },
@@ -64,7 +72,483 @@
             "properties": {
               "requestId": {
                 "type": "string",
-                "format": "uuid"
+                "format": "uuid",
+                "example": "00000000-0000-4000-8000-000000000000"
+              }
+            }
+          }
+        }
+      },
+      "Feed": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "example": 1
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "example": "https://example.com/rss.xml"
+          },
+          "title": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "My RSS feed"
+          },
+          "lastFetchedAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "example": null
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2025-01-20T12:34:56.000Z"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2025-01-20T12:34:56.000Z"
+          }
+        }
+      },
+      "FeedDuplicateEntry": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "example": "https://example.com/rss.xml"
+          },
+          "reason": {
+            "type": "string",
+            "example": "ALREADY_EXISTS",
+            "description": "Reason why the URL could not be created."
+          },
+          "feedId": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "example": 12,
+            "description": "Existing feed identifier when the duplicate already exists in the database."
+          }
+        }
+      },
+      "FeedInvalidEntry": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "example": "notaurl"
+          },
+          "reason": {
+            "type": "string",
+            "example": "INVALID_URL",
+            "description": "Validation reason for rejecting the URL."
+          }
+        }
+      },
+      "FeedBulkResult": {
+        "type": "object",
+        "properties": {
+          "created": {
+            "type": "array",
+            "description": "Feeds successfully created for the user.",
+            "items": {
+              "$ref": "#/components/schemas/Feed"
+            }
+          },
+          "duplicates": {
+            "type": "array",
+            "description": "URLs skipped because they already exist or were repeated in the payload.",
+            "items": {
+              "$ref": "#/components/schemas/FeedDuplicateEntry"
+            }
+          },
+          "invalid": {
+            "type": "array",
+            "description": "URLs rejected due to validation errors.",
+            "items": {
+              "$ref": "#/components/schemas/FeedInvalidEntry"
+            }
+          }
+        }
+      },
+      "FeedDeletionResult": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "example": "Feed removed"
+          }
+        }
+      },
+      "FeedRefreshSummary": {
+        "type": "object",
+        "properties": {
+          "feedId": {
+            "type": "integer",
+            "example": 42
+          },
+          "feedUrl": {
+            "type": "string",
+            "format": "uri",
+            "example": "https://news.example.com/rss"
+          },
+          "feedTitle": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "News"
+          },
+          "skippedByCooldown": {
+            "type": "boolean",
+            "example": false
+          },
+          "cooldownSecondsRemaining": {
+            "type": "integer",
+            "example": 0
+          },
+          "itemsRead": {
+            "type": "integer",
+            "example": 25
+          },
+          "itemsWithinWindow": {
+            "type": "integer",
+            "example": 8
+          },
+          "articlesCreated": {
+            "type": "integer",
+            "example": 3
+          },
+          "duplicates": {
+            "type": "integer",
+            "example": 2
+          },
+          "invalidItems": {
+            "type": "integer",
+            "example": 1
+          },
+          "error": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "example": null,
+            "properties": {
+              "message": {
+                "type": "string",
+                "example": "Feed request timed out"
+              }
+            },
+            "description": "Error returned when the feed fetch failed. Null when the refresh completed successfully."
+          }
+        }
+      },
+      "FeedRefreshResponse": {
+        "type": "object",
+        "properties": {
+          "now": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2025-01-20T12:34:56.000Z"
+          },
+          "feeds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FeedRefreshSummary"
+            }
+          }
+        }
+      },
+      "PostsCleanupResult": {
+        "type": "object",
+        "properties": {
+          "removedArticles": {
+            "type": "integer",
+            "example": 12
+          },
+          "removedPosts": {
+            "type": "integer",
+            "example": 12
+          }
+        }
+      },
+      "PostFeedReference": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "example": 7
+          },
+          "title": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "Tech Newsletter"
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uri",
+            "example": "https://tech.example.com/rss"
+          }
+        }
+      },
+      "PostContent": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string",
+            "example": "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+          },
+          "createdAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "example": "2025-01-20T12:35:30.000Z"
+          }
+        }
+      },
+      "PostListItem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "example": 99
+          },
+          "title": {
+            "type": "string",
+            "example": "Latest tech news"
+          },
+          "contentSnippet": {
+            "type": "string",
+            "example": "Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+          },
+          "publishedAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2025-01-20T10:00:00.000Z"
+          },
+          "feed": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PostFeedReference"
+              }
+            ],
+            "example": {
+              "id": 7,
+              "title": "Tech Newsletter",
+              "url": "https://tech.example.com/rss"
+            }
+          },
+          "post": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PostContent"
+              }
+            ],
+            "example": {
+              "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+              "createdAt": "2025-01-20T12:36:00.000Z"
+            }
+          }
+        }
+      },
+      "PostListResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PostListItem"
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "SessionCookie": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "lkd_session",
+        "description": "Sessão autenticada emitida após login com Google."
+      },
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "Session token",
+        "description": "Token de sessão transmitido via cabeçalho Authorization."
+      }
+    },
+    "responses": {
+      "BadRequest": {
+        "description": "Requisição inválida (parâmetros ou payload incorretos).",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorEnvelope"
+            },
+            "examples": {
+              "invalidInput": {
+                "summary": "Valor inválido informado",
+                "value": {
+                  "success": false,
+                  "error": {
+                    "code": "INVALID_INPUT",
+                    "message": "Invalid input data"
+                  },
+                  "meta": {
+                    "requestId": "00000000-0000-4000-8000-000000000000"
+                  }
+                }
+              },
+              "urlRequired": {
+                "summary": "URL obrigatória",
+                "value": {
+                  "success": false,
+                  "error": {
+                    "code": "URL_REQUIRED",
+                    "message": "URL is required"
+                  },
+                  "meta": {
+                    "requestId": "00000000-0000-4000-8000-000000000000"
+                  }
+                }
+              },
+              "invalidCursor": {
+                "summary": "Cursor de paginação inválido",
+                "value": {
+                  "success": false,
+                  "error": {
+                    "code": "INVALID_CURSOR",
+                    "message": "Invalid pagination cursor"
+                  },
+                  "meta": {
+                    "requestId": "00000000-0000-4000-8000-000000000000"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "Autenticação requerida.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorEnvelope"
+            },
+            "example": {
+              "success": false,
+              "error": {
+                "code": "UNAUTHENTICATED",
+                "message": "Authentication required"
+              },
+              "meta": {
+                "requestId": "00000000-0000-4000-8000-000000000000"
+              }
+            }
+          }
+        }
+      },
+      "Forbidden": {
+        "description": "Usuário autenticado sem permissão suficiente.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorEnvelope"
+            },
+            "example": {
+              "success": false,
+              "error": {
+                "code": "FORBIDDEN",
+                "message": "Insufficient permissions"
+              },
+              "meta": {
+                "requestId": "00000000-0000-4000-8000-000000000000"
+              }
+            }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "Recurso não encontrado.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorEnvelope"
+            },
+            "example": {
+              "success": false,
+              "error": {
+                "code": "FEED_NOT_FOUND",
+                "message": "Feed not found"
+              },
+              "meta": {
+                "requestId": "00000000-0000-4000-8000-000000000000"
+              }
+            }
+          }
+        }
+      },
+      "Conflict": {
+        "description": "Estado atual do recurso impede a operação.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorEnvelope"
+            },
+            "example": {
+              "success": false,
+              "error": {
+                "code": "FEED_ALREADY_EXISTS",
+                "message": "Feed already exists for this user"
+              },
+              "meta": {
+                "requestId": "00000000-0000-4000-8000-000000000000"
+              }
+            }
+          }
+        }
+      },
+      "PayloadTooLarge": {
+        "description": "Carga enviada excede os limites da API.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorEnvelope"
+            },
+            "example": {
+              "success": false,
+              "error": {
+                "code": "PAYLOAD_TOO_LARGE",
+                "message": "A maximum of 25 feeds can be created per request"
+              },
+              "meta": {
+                "requestId": "00000000-0000-4000-8000-000000000000"
               }
             }
           }
@@ -117,6 +601,545 @@
         }
       }
     },
+    "/api/v1/feeds": {
+      "get": {
+        "summary": "List RSS feeds owned by the authenticated user",
+        "description": "Retorna os feeds cadastrados pelo usuário autenticado usando envelope padronizado e paginação baseada em cursor.",
+        "tags": [
+          "Feeds"
+        ],
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "cursor",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Cursor retornado em chamadas anteriores para continuar a paginação."
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50
+            },
+            "description": "Quantidade máxima de feeds retornados por página (padrão 20, limite 50)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of feeds",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Envelope"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/components/schemas/Feed"
+                              }
+                            }
+                          }
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "requestId": {
+                              "type": "string",
+                              "format": "uuid"
+                            },
+                            "nextCursor": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "Cursor da próxima página ou null quando não há mais resultados."
+                            },
+                            "total": {
+                              "type": "integer",
+                              "description": "Total de feeds cadastrados para o usuário."
+                            },
+                            "limit": {
+                              "type": "integer",
+                              "description": "Limite efetivamente aplicado."
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Lista paginada de feeds",
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "items": [
+                          {
+                            "id": 1,
+                            "url": "https://example.com/rss.xml",
+                            "title": "Example RSS",
+                            "lastFetchedAt": "2025-01-20T12:00:00.000Z",
+                            "createdAt": "2025-01-10T09:30:00.000Z",
+                            "updatedAt": "2025-01-18T08:15:00.000Z"
+                          }
+                        ]
+                      },
+                      "meta": {
+                        "requestId": "11111111-2222-4333-8444-555555555555",
+                        "nextCursor": "2",
+                        "total": 3,
+                        "limit": 20
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a new RSS feed for the authenticated user",
+        "description": "Registra um novo feed RSS associado ao usuário autenticado. URLs duplicadas são rejeitadas.",
+        "tags": [
+          "Feeds"
+        ],
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "url"
+                ],
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "title": {
+                    "type": "string",
+                    "nullable": true
+                  }
+                }
+              },
+              "examples": {
+                "minimal": {
+                  "summary": "Criação básica",
+                  "value": {
+                    "url": "https://example.com/rss.xml"
+                  }
+                },
+                "withTitle": {
+                  "summary": "Incluindo título opcional",
+                  "value": {
+                    "url": "https://example.com/rss.xml",
+                    "title": "Example RSS Feed"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Feed created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Envelope"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/Feed"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "examples": {
+                  "created": {
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "id": 4,
+                        "url": "https://example.com/rss.xml",
+                        "title": "Example RSS Feed",
+                        "lastFetchedAt": null,
+                        "createdAt": "2025-01-20T12:34:56.000Z",
+                        "updatedAt": "2025-01-20T12:34:56.000Z"
+                      },
+                      "meta": {
+                        "requestId": "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          }
+        }
+      }
+    },
+    "/api/v1/feeds/bulk": {
+      "post": {
+        "summary": "Create multiple RSS feeds in a single request",
+        "description": "Recebe até 25 URLs por requisição, ignorando duplicadas e reportando entradas inválidas sem interromper o processamento.",
+        "tags": [
+          "Feeds"
+        ],
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "urls"
+                ],
+                "properties": {
+                  "urls": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  }
+                }
+              },
+              "examples": {
+                "sample": {
+                  "value": {
+                    "urls": [
+                      "https://example.com/rss.xml",
+                      "https://news.example.com/feed"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Result of the bulk creation request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Envelope"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/FeedBulkResult"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "examples": {
+                  "processed": {
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "created": [
+                          {
+                            "id": 5,
+                            "url": "https://example.com/rss.xml",
+                            "title": null,
+                            "lastFetchedAt": null,
+                            "createdAt": "2025-01-20T12:34:56.000Z",
+                            "updatedAt": "2025-01-20T12:34:56.000Z"
+                          }
+                        ],
+                        "duplicates": [
+                          {
+                            "url": "https://example.com/rss.xml",
+                            "reason": "ALREADY_EXISTS",
+                            "feedId": 2
+                          },
+                          {
+                            "url": "https://example.com/rss.xml",
+                            "reason": "DUPLICATE_IN_PAYLOAD",
+                            "feedId": null
+                          }
+                        ],
+                        "invalid": [
+                          {
+                            "url": "notaurl",
+                            "reason": "INVALID_URL"
+                          },
+                          {
+                            "url": "",
+                            "reason": "URL_REQUIRED"
+                          }
+                        ]
+                      },
+                      "meta": {
+                        "requestId": "11111111-2222-4333-8444-555555555555"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "413": {
+            "$ref": "#/components/responses/PayloadTooLarge"
+          }
+        }
+      }
+    },
+    "/api/v1/feeds/{id}": {
+      "patch": {
+        "summary": "Update attributes of an existing feed",
+        "description": "Permite atualizar URL e título de um feed pertencente ao usuário autenticado.",
+        "tags": [
+          "Feeds"
+        ],
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "title": {
+                    "type": "string",
+                    "nullable": true
+                  }
+                }
+              },
+              "examples": {
+                "updateTitle": {
+                  "value": {
+                    "title": "Novo título"
+                  }
+                },
+                "updateUrl": {
+                  "value": {
+                    "url": "https://example.com/rss.xml"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Feed updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Envelope"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/Feed"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "examples": {
+                  "updated": {
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "id": 2,
+                        "url": "https://example.com/rss.xml",
+                        "title": "Novo título",
+                        "lastFetchedAt": "2025-01-18T08:15:00.000Z",
+                        "createdAt": "2024-12-01T12:00:00.000Z",
+                        "updatedAt": "2025-01-20T12:40:00.000Z"
+                      },
+                      "meta": {
+                        "requestId": "99999999-8888-4777-8666-555555555555"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Remove a feed owned by the authenticated user",
+        "description": "Exclui definitivamente o feed informado e os dados associados ao usuário autenticado.",
+        "tags": [
+          "Feeds"
+        ],
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Feed removed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Envelope"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/FeedDeletionResult"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "examples": {
+                  "removed": {
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "message": "Feed removed"
+                      },
+                      "meta": {
+                        "requestId": "22222222-3333-4444-8555-666666666666"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
     "/api/v1/hello": {
       "get": {
         "summary": "Returns the hello message",
@@ -156,6 +1179,289 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/api/v1/posts/refresh": {
+      "post": {
+        "summary": "Refresh articles and generate posts from configured feeds",
+        "description": "Consulta todos os feeds do usuário autenticado, aplica a janela de retenção configurada e cria posts placeholder para notícias recentes.",
+        "tags": [
+          "Posts"
+        ],
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Refresh executed for every feed owned by the user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Envelope"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/FeedRefreshResponse"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "examples": {
+                  "success": {
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "now": "2025-01-20T12:34:56.000Z",
+                        "feeds": [
+                          {
+                            "feedId": 1,
+                            "feedUrl": "https://example.com/rss.xml",
+                            "feedTitle": "Example RSS",
+                            "skippedByCooldown": false,
+                            "cooldownSecondsRemaining": 0,
+                            "itemsRead": 12,
+                            "itemsWithinWindow": 4,
+                            "articlesCreated": 2,
+                            "duplicates": 1,
+                            "invalidItems": 0,
+                            "error": null
+                          },
+                          {
+                            "feedId": 2,
+                            "feedUrl": "https://news.example.com/feed",
+                            "feedTitle": null,
+                            "skippedByCooldown": true,
+                            "cooldownSecondsRemaining": 1800,
+                            "itemsRead": 0,
+                            "itemsWithinWindow": 0,
+                            "articlesCreated": 0,
+                            "duplicates": 0,
+                            "invalidItems": 0,
+                            "error": {
+                              "message": "Feed request timed out"
+                            }
+                          }
+                        ]
+                      },
+                      "meta": {
+                        "requestId": "77777777-8888-4999-8aaa-bbbbbbbbbbbb"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/v1/posts/cleanup": {
+      "post": {
+        "summary": "Delete old articles and posts outside the retention window",
+        "description": "Remove artigos e posts vinculados aos feeds do usuário autenticado que estejam fora da janela de 7 dias utilizada pelo sistema.",
+        "tags": [
+          "Posts"
+        ],
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cleanup executed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Envelope"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/PostsCleanupResult"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "examples": {
+                  "success": {
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "removedArticles": 6,
+                        "removedPosts": 6
+                      },
+                      "meta": {
+                        "requestId": "12345678-90ab-4cde-8fab-1234567890ab"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/v1/posts": {
+      "get": {
+        "summary": "List generated posts derived from recent feed entries",
+        "description": "Retorna artigos normalizados com o conteúdo de post correspondente, aplicando ordenação decrescente por data e paginação por cursor.",
+        "tags": [
+          "Posts"
+        ],
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "cursor",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Cursor de paginação retornado em chamadas anteriores."
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50
+            },
+            "description": "Quantidade de itens por página (padrão 20, máximo 50)."
+          },
+          {
+            "in": "query",
+            "name": "feedId",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Filtra os artigos pertencentes ao feed informado."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of recent posts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Envelope"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/PostListResponse"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "requestId": {
+                              "type": "string",
+                              "format": "uuid"
+                            },
+                            "nextCursor": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "Cursor para a próxima página ou null ao final da lista."
+                            },
+                            "limit": {
+                              "type": "integer",
+                              "description": "Limite aplicado à consulta."
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                "examples": {
+                  "success": {
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "items": [
+                          {
+                            "id": 101,
+                            "title": "Nova parceria anunciada",
+                            "contentSnippet": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                            "publishedAt": "2025-01-20T09:00:00.000Z",
+                            "feed": {
+                              "id": 1,
+                              "title": "Example RSS",
+                              "url": "https://example.com/rss.xml"
+                            },
+                            "post": {
+                              "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                              "createdAt": "2025-01-20T12:35:00.000Z"
+                            }
+                          },
+                          {
+                            "id": 102,
+                            "title": "Tech Weekly 42",
+                            "contentSnippet": "Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+                            "publishedAt": "2025-01-19T17:30:00.000Z",
+                            "feed": {
+                              "id": 2,
+                              "title": null,
+                              "url": "https://news.example.com/feed"
+                            },
+                            "post": null
+                          }
+                        ]
+                      },
+                      "meta": {
+                        "requestId": "55555555-6666-4777-8888-999999999999",
+                        "nextCursor": "MjAyNS0wMS0xOVQxNzozMDowMC4wMDBaOjEwMg==",
+                        "limit": 20
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
           }
         }
       }

--- a/backend/src/docs/openapi.js
+++ b/backend/src/docs/openapi.js
@@ -21,11 +21,15 @@ const definition = {
         type: 'object',
         properties: {
           success: { type: 'boolean', example: true },
-          data: { type: 'object' },
+          data: { type: ['object', 'null'] },
           meta: {
             type: 'object',
             properties: {
-              requestId: { type: 'string', format: 'uuid' },
+              requestId: {
+                type: 'string',
+                format: 'uuid',
+                example: '00000000-0000-4000-8000-000000000000',
+              },
             },
           },
         },
@@ -39,13 +43,17 @@ const definition = {
             properties: {
               code: { type: 'string', example: 'INTERNAL_SERVER_ERROR' },
               message: { type: 'string', example: 'Internal server error' },
-              details: { type: 'object' },
+              details: { type: ['object', 'null'], example: null },
             },
           },
           meta: {
             type: 'object',
             properties: {
-              requestId: { type: 'string', format: 'uuid' },
+              requestId: {
+                type: 'string',
+                format: 'uuid',
+                example: '00000000-0000-4000-8000-000000000000',
+              },
             },
           },
         },
@@ -56,9 +64,40 @@ const definition = {
           id: { type: 'integer', example: 1 },
           url: { type: 'string', format: 'uri', example: 'https://example.com/rss.xml' },
           title: { type: ['string', 'null'], example: 'My RSS feed' },
-          lastFetchedAt: { type: ['string', 'null'], format: 'date-time', example: null },
+          lastFetchedAt: {
+            type: ['string', 'null'],
+            format: 'date-time',
+            example: null,
+          },
           createdAt: { type: 'string', format: 'date-time', example: '2025-01-20T12:34:56.000Z' },
           updatedAt: { type: 'string', format: 'date-time', example: '2025-01-20T12:34:56.000Z' },
+        },
+      },
+      FeedDuplicateEntry: {
+        type: 'object',
+        properties: {
+          url: { type: 'string', format: 'uri', example: 'https://example.com/rss.xml' },
+          reason: {
+            type: 'string',
+            example: 'ALREADY_EXISTS',
+            description: 'Reason why the URL could not be created.',
+          },
+          feedId: {
+            type: ['integer', 'null'],
+            example: 12,
+            description: 'Existing feed identifier when the duplicate already exists in the database.',
+          },
+        },
+      },
+      FeedInvalidEntry: {
+        type: 'object',
+        properties: {
+          url: { type: 'string', example: 'notaurl' },
+          reason: {
+            type: 'string',
+            example: 'INVALID_URL',
+            description: 'Validation reason for rejecting the URL.',
+          },
         },
       },
       FeedBulkResult: {
@@ -66,26 +105,290 @@ const definition = {
         properties: {
           created: {
             type: 'array',
+            description: 'Feeds successfully created for the user.',
             items: { $ref: '#/components/schemas/Feed' },
           },
           duplicates: {
             type: 'array',
-            items: {
-              type: 'object',
-              properties: {
-                url: { type: 'string', format: 'uri' },
-                reason: { type: 'string', example: 'ALREADY_EXISTS' },
-                feedId: { type: ['integer', 'null'], example: 1 },
-              },
-            },
+            description: 'URLs skipped because they already exist or were repeated in the payload.',
+            items: { $ref: '#/components/schemas/FeedDuplicateEntry' },
           },
           invalid: {
             type: 'array',
-            items: {
-              type: 'object',
-              properties: {
-                url: { type: 'string' },
-                reason: { type: 'string', example: 'INVALID_URL' },
+            description: 'URLs rejected due to validation errors.',
+            items: { $ref: '#/components/schemas/FeedInvalidEntry' },
+          },
+        },
+      },
+      FeedDeletionResult: {
+        type: 'object',
+        properties: {
+          message: { type: 'string', example: 'Feed removed' },
+        },
+      },
+      FeedRefreshSummary: {
+        type: 'object',
+        properties: {
+          feedId: { type: 'integer', example: 42 },
+          feedUrl: {
+            type: 'string',
+            format: 'uri',
+            example: 'https://news.example.com/rss',
+          },
+          feedTitle: { type: ['string', 'null'], example: 'News' },
+          skippedByCooldown: { type: 'boolean', example: false },
+          cooldownSecondsRemaining: { type: 'integer', example: 0 },
+          itemsRead: { type: 'integer', example: 25 },
+          itemsWithinWindow: { type: 'integer', example: 8 },
+          articlesCreated: { type: 'integer', example: 3 },
+          duplicates: { type: 'integer', example: 2 },
+          invalidItems: { type: 'integer', example: 1 },
+          error: {
+            type: ['object', 'null'],
+            example: null,
+            properties: {
+              message: { type: 'string', example: 'Feed request timed out' },
+            },
+            description:
+              'Error returned when the feed fetch failed. Null when the refresh completed successfully.',
+          },
+        },
+      },
+      FeedRefreshResponse: {
+        type: 'object',
+        properties: {
+          now: {
+            type: 'string',
+            format: 'date-time',
+            example: '2025-01-20T12:34:56.000Z',
+          },
+          feeds: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/FeedRefreshSummary' },
+          },
+        },
+      },
+      PostsCleanupResult: {
+        type: 'object',
+        properties: {
+          removedArticles: { type: 'integer', example: 12 },
+          removedPosts: { type: 'integer', example: 12 },
+        },
+      },
+      PostFeedReference: {
+        type: 'object',
+        properties: {
+          id: { type: 'integer', example: 7 },
+          title: { type: ['string', 'null'], example: 'Tech Newsletter' },
+          url: {
+            type: ['string', 'null'],
+            format: 'uri',
+            example: 'https://tech.example.com/rss',
+          },
+        },
+      },
+      PostContent: {
+        type: 'object',
+        properties: {
+          content: {
+            type: 'string',
+            example: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+          },
+          createdAt: {
+            type: ['string', 'null'],
+            format: 'date-time',
+            example: '2025-01-20T12:35:30.000Z',
+          },
+        },
+      },
+      PostListItem: {
+        type: 'object',
+        properties: {
+          id: { type: 'integer', example: 99 },
+          title: { type: 'string', example: 'Latest tech news' },
+          contentSnippet: {
+            type: 'string',
+            example: 'Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+          },
+          publishedAt: {
+            type: 'string',
+            format: 'date-time',
+            example: '2025-01-20T10:00:00.000Z',
+          },
+          feed: {
+            type: ['object', 'null'],
+            allOf: [{ $ref: '#/components/schemas/PostFeedReference' }],
+            example: { id: 7, title: 'Tech Newsletter', url: 'https://tech.example.com/rss' },
+          },
+          post: {
+            type: ['object', 'null'],
+            allOf: [{ $ref: '#/components/schemas/PostContent' }],
+            example: {
+              content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+              createdAt: '2025-01-20T12:36:00.000Z',
+            },
+          },
+        },
+      },
+      PostListResponse: {
+        type: 'object',
+        properties: {
+          items: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/PostListItem' },
+          },
+        },
+      },
+    },
+    securitySchemes: {
+      SessionCookie: {
+        type: 'apiKey',
+        in: 'cookie',
+        name: config.auth.session.cookieName,
+        description: 'Sessão autenticada emitida após login com Google.',
+      },
+      BearerAuth: {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'Session token',
+        description: 'Token de sessão transmitido via cabeçalho Authorization.',
+      },
+    },
+    responses: {
+      BadRequest: {
+        description: 'Requisição inválida (parâmetros ou payload incorretos).',
+        content: {
+          'application/json': {
+            schema: { $ref: '#/components/schemas/ErrorEnvelope' },
+            examples: {
+              invalidInput: {
+                summary: 'Valor inválido informado',
+                value: {
+                  success: false,
+                  error: {
+                    code: 'INVALID_INPUT',
+                    message: 'Invalid input data',
+                  },
+                  meta: {
+                    requestId: '00000000-0000-4000-8000-000000000000',
+                  },
+                },
+              },
+              urlRequired: {
+                summary: 'URL obrigatória',
+                value: {
+                  success: false,
+                  error: {
+                    code: 'URL_REQUIRED',
+                    message: 'URL is required',
+                  },
+                  meta: {
+                    requestId: '00000000-0000-4000-8000-000000000000',
+                  },
+                },
+              },
+              invalidCursor: {
+                summary: 'Cursor de paginação inválido',
+                value: {
+                  success: false,
+                  error: {
+                    code: 'INVALID_CURSOR',
+                    message: 'Invalid pagination cursor',
+                  },
+                  meta: {
+                    requestId: '00000000-0000-4000-8000-000000000000',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      Unauthorized: {
+        description: 'Autenticação requerida.',
+        content: {
+          'application/json': {
+            schema: { $ref: '#/components/schemas/ErrorEnvelope' },
+            example: {
+              success: false,
+              error: {
+                code: 'UNAUTHENTICATED',
+                message: 'Authentication required',
+              },
+              meta: {
+                requestId: '00000000-0000-4000-8000-000000000000',
+              },
+            },
+          },
+        },
+      },
+      Forbidden: {
+        description: 'Usuário autenticado sem permissão suficiente.',
+        content: {
+          'application/json': {
+            schema: { $ref: '#/components/schemas/ErrorEnvelope' },
+            example: {
+              success: false,
+              error: {
+                code: 'FORBIDDEN',
+                message: 'Insufficient permissions',
+              },
+              meta: {
+                requestId: '00000000-0000-4000-8000-000000000000',
+              },
+            },
+          },
+        },
+      },
+      NotFound: {
+        description: 'Recurso não encontrado.',
+        content: {
+          'application/json': {
+            schema: { $ref: '#/components/schemas/ErrorEnvelope' },
+            example: {
+              success: false,
+              error: {
+                code: 'FEED_NOT_FOUND',
+                message: 'Feed not found',
+              },
+              meta: {
+                requestId: '00000000-0000-4000-8000-000000000000',
+              },
+            },
+          },
+        },
+      },
+      Conflict: {
+        description: 'Estado atual do recurso impede a operação.',
+        content: {
+          'application/json': {
+            schema: { $ref: '#/components/schemas/ErrorEnvelope' },
+            example: {
+              success: false,
+              error: {
+                code: 'FEED_ALREADY_EXISTS',
+                message: 'Feed already exists for this user',
+              },
+              meta: {
+                requestId: '00000000-0000-4000-8000-000000000000',
+              },
+            },
+          },
+        },
+      },
+      PayloadTooLarge: {
+        description: 'Carga enviada excede os limites da API.',
+        content: {
+          'application/json': {
+            schema: { $ref: '#/components/schemas/ErrorEnvelope' },
+            example: {
+              success: false,
+              error: {
+                code: 'PAYLOAD_TOO_LARGE',
+                message: 'A maximum of 25 feeds can be created per request',
+              },
+              meta: {
+                requestId: '00000000-0000-4000-8000-000000000000',
               },
             },
           },

--- a/backend/src/routes/v1/feed.routes.js
+++ b/backend/src/routes/v1/feed.routes.js
@@ -8,21 +8,25 @@ const router = express.Router();
  * /api/v1/feeds:
  *   get:
  *     summary: List RSS feeds owned by the authenticated user
+ *     description: Retorna os feeds cadastrados pelo usuário autenticado usando envelope padronizado e paginação baseada em cursor.
  *     tags:
  *       - Feeds
+ *     security:
+ *       - SessionCookie: []
+ *       - BearerAuth: []
  *     parameters:
  *       - in: query
  *         name: cursor
  *         schema:
  *           type: string
- *           description: Cursor pointing to the last feed received in the previous page
+ *         description: Cursor retornado em chamadas anteriores para continuar a paginação.
  *       - in: query
  *         name: limit
  *         schema:
  *           type: integer
  *           minimum: 1
  *           maximum: 50
- *         description: Maximum number of feeds to return per request
+ *         description: Quantidade máxima de feeds retornados por página (padrão 20, limite 50).
  *     responses:
  *       '200':
  *         description: Paginated list of feeds
@@ -43,17 +47,48 @@ const router = express.Router();
  *                     meta:
  *                       type: object
  *                       properties:
- *                         nextCursor:
+ *                         requestId:
  *                           type: string
- *                           nullable: true
+ *                           format: uuid
+ *                         nextCursor:
+ *                           type: ['string', 'null']
+ *                           description: Cursor da próxima página ou null quando não há mais resultados.
  *                         total:
  *                           type: integer
+ *                           description: Total de feeds cadastrados para o usuário.
  *                         limit:
  *                           type: integer
+ *                           description: Limite efetivamente aplicado.
+ *             examples:
+ *               success:
+ *                 summary: Lista paginada de feeds
+ *                 value:
+ *                   success: true
+ *                   data:
+ *                     items:
+ *                       - id: 1
+ *                         url: https://example.com/rss.xml
+ *                         title: Example RSS
+ *                         lastFetchedAt: '2025-01-20T12:00:00.000Z'
+ *                         createdAt: '2025-01-10T09:30:00.000Z'
+ *                         updatedAt: '2025-01-18T08:15:00.000Z'
+ *                   meta:
+ *                     requestId: 11111111-2222-4333-8444-555555555555
+ *                     nextCursor: '2'
+ *                     total: 3
+ *                     limit: 20
+ *       '400':
+ *         $ref: '#/components/responses/BadRequest'
+ *       '401':
+ *         $ref: '#/components/responses/Unauthorized'
  *   post:
  *     summary: Create a new RSS feed for the authenticated user
+ *     description: Registra um novo feed RSS associado ao usuário autenticado. URLs duplicadas são rejeitadas.
  *     tags:
  *       - Feeds
+ *     security:
+ *       - SessionCookie: []
+ *       - BearerAuth: []
  *     requestBody:
  *       required: true
  *       content:
@@ -69,6 +104,16 @@ const router = express.Router();
  *               title:
  *                 type: string
  *                 nullable: true
+ *           examples:
+ *             minimal:
+ *               summary: Criação básica
+ *               value:
+ *                 url: https://example.com/rss.xml
+ *             withTitle:
+ *               summary: Incluindo título opcional
+ *               value:
+ *                 url: https://example.com/rss.xml
+ *                 title: Example RSS Feed
  *     responses:
  *       '201':
  *         description: Feed created successfully
@@ -81,7 +126,26 @@ const router = express.Router();
  *                   properties:
  *                     data:
  *                       $ref: '#/components/schemas/Feed'
- */
+ *             examples:
+ *               created:
+ *                 value:
+ *                   success: true
+ *                   data:
+ *                     id: 4
+ *                     url: https://example.com/rss.xml
+ *                     title: Example RSS Feed
+ *                     lastFetchedAt: null
+ *                     createdAt: '2025-01-20T12:34:56.000Z'
+ *                     updatedAt: '2025-01-20T12:34:56.000Z'
+ *                   meta:
+ *                     requestId: aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee
+ *       '400':
+ *         $ref: '#/components/responses/BadRequest'
+ *       '401':
+ *         $ref: '#/components/responses/Unauthorized'
+ *       '409':
+ *         $ref: '#/components/responses/Conflict'
+*/
 router.get('/feeds', feedController.list);
 router.post('/feeds', feedController.create);
 
@@ -90,8 +154,12 @@ router.post('/feeds', feedController.create);
  * /api/v1/feeds/bulk:
  *   post:
  *     summary: Create multiple RSS feeds in a single request
+ *     description: Recebe até 25 URLs por requisição, ignorando duplicadas e reportando entradas inválidas sem interromper o processamento.
  *     tags:
  *       - Feeds
+ *     security:
+ *       - SessionCookie: []
+ *       - BearerAuth: []
  *     requestBody:
  *       required: true
  *       content:
@@ -106,6 +174,12 @@ router.post('/feeds', feedController.create);
  *                 items:
  *                   type: string
  *                   format: uri
+ *           examples:
+ *             sample:
+ *               value:
+ *                 urls:
+ *                   - https://example.com/rss.xml
+ *                   - https://news.example.com/feed
  *     responses:
  *       '200':
  *         description: Result of the bulk creation request
@@ -118,6 +192,38 @@ router.post('/feeds', feedController.create);
  *                   properties:
  *                     data:
  *                       $ref: '#/components/schemas/FeedBulkResult'
+ *             examples:
+ *               processed:
+ *                 value:
+ *                   success: true
+ *                   data:
+ *                     created:
+ *                       - id: 5
+ *                         url: https://example.com/rss.xml
+ *                         title: null
+ *                         lastFetchedAt: null
+ *                         createdAt: '2025-01-20T12:34:56.000Z'
+ *                         updatedAt: '2025-01-20T12:34:56.000Z'
+ *                     duplicates:
+ *                       - url: https://example.com/rss.xml
+ *                         reason: ALREADY_EXISTS
+ *                         feedId: 2
+ *                       - url: https://example.com/rss.xml
+ *                         reason: DUPLICATE_IN_PAYLOAD
+ *                         feedId: null
+ *                     invalid:
+ *                       - url: notaurl
+ *                         reason: INVALID_URL
+ *                       - url: ''
+ *                         reason: URL_REQUIRED
+ *                   meta:
+ *                     requestId: 11111111-2222-4333-8444-555555555555
+ *       '400':
+ *         $ref: '#/components/responses/BadRequest'
+ *       '401':
+ *         $ref: '#/components/responses/Unauthorized'
+ *       '413':
+ *         $ref: '#/components/responses/PayloadTooLarge'
  */
 router.post('/feeds/bulk', feedController.bulkCreate);
 
@@ -126,8 +232,12 @@ router.post('/feeds/bulk', feedController.bulkCreate);
  * /api/v1/feeds/{id}:
  *   patch:
  *     summary: Update attributes of an existing feed
+ *     description: Permite atualizar URL e título de um feed pertencente ao usuário autenticado.
  *     tags:
  *       - Feeds
+ *     security:
+ *       - SessionCookie: []
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id
@@ -147,6 +257,13 @@ router.post('/feeds/bulk', feedController.bulkCreate);
  *               title:
  *                 type: string
  *                 nullable: true
+ *           examples:
+ *             updateTitle:
+ *               value:
+ *                 title: Novo título
+ *             updateUrl:
+ *               value:
+ *                 url: https://example.com/rss.xml
  *     responses:
  *       '200':
  *         description: Feed updated successfully
@@ -159,10 +276,35 @@ router.post('/feeds/bulk', feedController.bulkCreate);
  *                   properties:
  *                     data:
  *                       $ref: '#/components/schemas/Feed'
+ *             examples:
+ *               updated:
+ *                 value:
+ *                   success: true
+ *                   data:
+ *                     id: 2
+ *                     url: https://example.com/rss.xml
+ *                     title: Novo título
+ *                     lastFetchedAt: '2025-01-18T08:15:00.000Z'
+ *                     createdAt: '2024-12-01T12:00:00.000Z'
+ *                     updatedAt: '2025-01-20T12:40:00.000Z'
+ *                   meta:
+ *                     requestId: 99999999-8888-4777-8666-555555555555
+ *       '400':
+ *         $ref: '#/components/responses/BadRequest'
+ *       '401':
+ *         $ref: '#/components/responses/Unauthorized'
+ *       '404':
+ *         $ref: '#/components/responses/NotFound'
+ *       '409':
+ *         $ref: '#/components/responses/Conflict'
  *   delete:
  *     summary: Remove a feed owned by the authenticated user
+ *     description: Exclui definitivamente o feed informado e os dados associados ao usuário autenticado.
  *     tags:
  *       - Feeds
+ *     security:
+ *       - SessionCookie: []
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id
@@ -180,10 +322,21 @@ router.post('/feeds/bulk', feedController.bulkCreate);
  *                 - type: object
  *                   properties:
  *                     data:
- *                       type: object
- *                       properties:
- *                         message:
- *                           type: string
+ *                       $ref: '#/components/schemas/FeedDeletionResult'
+ *             examples:
+ *               removed:
+ *                 value:
+ *                   success: true
+ *                   data:
+ *                     message: Feed removed
+ *                   meta:
+ *                     requestId: 22222222-3333-4444-8555-666666666666
+ *       '400':
+ *         $ref: '#/components/responses/BadRequest'
+ *       '401':
+ *         $ref: '#/components/responses/Unauthorized'
+ *       '404':
+ *         $ref: '#/components/responses/NotFound'
  */
 router.patch('/feeds/:id', feedController.update);
 router.delete('/feeds/:id', feedController.remove);

--- a/backend/src/routes/v1/posts.routes.js
+++ b/backend/src/routes/v1/posts.routes.js
@@ -4,8 +4,191 @@ const postsController = require('../../controllers/posts.controller');
 
 const router = express.Router();
 
+/**
+ * @openapi
+ * /api/v1/posts/refresh:
+ *   post:
+ *     summary: Refresh articles and generate posts from configured feeds
+ *     description: Consulta todos os feeds do usuário autenticado, aplica a janela de retenção configurada e cria posts placeholder para notícias recentes.
+ *     tags:
+ *       - Posts
+ *     security:
+ *       - SessionCookie: []
+ *       - BearerAuth: []
+ *     responses:
+ *       '200':
+ *         description: Refresh executed for every feed owned by the user
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Envelope'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       $ref: '#/components/schemas/FeedRefreshResponse'
+ *             examples:
+ *               success:
+ *                 value:
+ *                   success: true
+ *                   data:
+ *                     now: '2025-01-20T12:34:56.000Z'
+ *                     feeds:
+ *                       - feedId: 1
+ *                         feedUrl: https://example.com/rss.xml
+ *                         feedTitle: Example RSS
+ *                         skippedByCooldown: false
+ *                         cooldownSecondsRemaining: 0
+ *                         itemsRead: 12
+ *                         itemsWithinWindow: 4
+ *                         articlesCreated: 2
+ *                         duplicates: 1
+ *                         invalidItems: 0
+ *                         error: null
+ *                       - feedId: 2
+ *                         feedUrl: https://news.example.com/feed
+ *                         feedTitle: null
+ *                         skippedByCooldown: true
+ *                         cooldownSecondsRemaining: 1800
+ *                         itemsRead: 0
+ *                         itemsWithinWindow: 0
+ *                         articlesCreated: 0
+ *                         duplicates: 0
+ *                         invalidItems: 0
+ *                         error:
+ *                           message: Feed request timed out
+ *                   meta:
+ *                     requestId: 77777777-8888-4999-8aaa-bbbbbbbbbbbb
+ *       '401':
+ *         $ref: '#/components/responses/Unauthorized'
+ */
 router.post('/posts/refresh', postsController.refresh);
+
+/**
+ * @openapi
+ * /api/v1/posts/cleanup:
+ *   post:
+ *     summary: Delete old articles and posts outside the retention window
+ *     description: Remove artigos e posts vinculados aos feeds do usuário autenticado que estejam fora da janela de 7 dias utilizada pelo sistema.
+ *     tags:
+ *       - Posts
+ *     security:
+ *       - SessionCookie: []
+ *       - BearerAuth: []
+ *     responses:
+ *       '200':
+ *         description: Cleanup executed successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Envelope'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       $ref: '#/components/schemas/PostsCleanupResult'
+ *             examples:
+ *               success:
+ *                 value:
+ *                   success: true
+ *                   data:
+ *                     removedArticles: 6
+ *                     removedPosts: 6
+ *                   meta:
+ *                     requestId: 12345678-90ab-4cde-8fab-1234567890ab
+ *       '401':
+ *         $ref: '#/components/responses/Unauthorized'
+ */
 router.post('/posts/cleanup', postsController.cleanup);
+
+/**
+ * @openapi
+ * /api/v1/posts:
+ *   get:
+ *     summary: List generated posts derived from recent feed entries
+ *     description: Retorna artigos normalizados com o conteúdo de post correspondente, aplicando ordenação decrescente por data e paginação por cursor.
+ *     tags:
+ *       - Posts
+ *     security:
+ *       - SessionCookie: []
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: cursor
+ *         schema:
+ *           type: string
+ *         description: Cursor de paginação retornado em chamadas anteriores.
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 50
+ *         description: Quantidade de itens por página (padrão 20, máximo 50).
+ *       - in: query
+ *         name: feedId
+ *         schema:
+ *           type: integer
+ *         description: Filtra os artigos pertencentes ao feed informado.
+ *     responses:
+ *       '200':
+ *         description: Paginated list of recent posts
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Envelope'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       $ref: '#/components/schemas/PostListResponse'
+ *                     meta:
+ *                       type: object
+ *                       properties:
+ *                         requestId:
+ *                           type: string
+ *                           format: uuid
+ *                         nextCursor:
+ *                           type: ['string', 'null']
+ *                           description: Cursor para a próxima página ou null ao final da lista.
+ *                         limit:
+ *                           type: integer
+ *                           description: Limite aplicado à consulta.
+ *             examples:
+ *               success:
+ *                 value:
+ *                   success: true
+ *                   data:
+ *                     items:
+ *                       - id: 101
+ *                         title: Nova parceria anunciada
+ *                         contentSnippet: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+ *                         publishedAt: '2025-01-20T09:00:00.000Z'
+ *                         feed:
+ *                           id: 1
+ *                           title: Example RSS
+ *                           url: https://example.com/rss.xml
+ *                         post:
+ *                           content: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+ *                           createdAt: '2025-01-20T12:35:00.000Z'
+ *                       - id: 102
+ *                         title: Tech Weekly 42
+ *                         contentSnippet: Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+ *                         publishedAt: '2025-01-19T17:30:00.000Z'
+ *                         feed:
+ *                           id: 2
+ *                           title: null
+ *                           url: https://news.example.com/feed
+ *                         post: null
+ *                   meta:
+ *                     requestId: 55555555-6666-4777-8888-999999999999
+ *                     nextCursor: MjAyNS0wMS0xOVQxNzozMDowMC4wMDBaOjEwMg==
+ *                     limit: 20
+ *       '400':
+ *         $ref: '#/components/responses/BadRequest'
+ *       '401':
+ *         $ref: '#/components/responses/Unauthorized'
+ */
 router.get('/posts', postsController.list);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- expand the shared OpenAPI components and responses to cover all feed and post endpoints with authentication details, payload schemas, and error examples
- document the posts routes and enrich feed route annotations so each operation includes request samples, pagination metadata, and failure scenarios
- rewrite the README with end-to-end setup guidance, environment variable tables, local development workflow, deployment steps, and testing instructions

## Testing
- npm run docs:generate --prefix backend

------
https://chatgpt.com/codex/tasks/task_e_68d08cfc83e08325a36e3b46569104cb