### PR TITLE
Ensure feed lists refresh immediately after creating feeds

### DIFF
--- a/frontend/src/features/feeds/hooks/useFeeds.ts
+++ b/frontend/src/features/feeds/hooks/useFeeds.ts
@@ -1,4 +1,10 @@
-import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type QueryClient,
+} from '@tanstack/react-query';
 
 import {
   FEEDS_QUERY_KEY,
@@ -12,6 +18,88 @@ import {
 import type { Feed, FeedBulkResult } from '../types/feed';
 import { HttpError } from '@/lib/api/http';
 import { useAuth } from '@/features/auth/hooks/useAuth';
+
+type FeedListQueryParams = {
+  cursor: string | null;
+  limit: number;
+};
+
+type FeedListQueryKey = readonly [...typeof FEEDS_QUERY_KEY, FeedListQueryParams];
+
+const isFeedListQueryKey = (queryKey: unknown): queryKey is FeedListQueryKey => {
+  if (!Array.isArray(queryKey)) {
+    return false;
+  }
+
+  if (queryKey.length !== FEEDS_QUERY_KEY.length + 1) {
+    return false;
+  }
+
+  const matchesBaseKey = FEEDS_QUERY_KEY.every((segment, index) => queryKey[index] === segment);
+
+  if (!matchesBaseKey) {
+    return false;
+  }
+
+  const params = queryKey[FEEDS_QUERY_KEY.length];
+
+  if (typeof params !== 'object' || params === null) {
+    return false;
+  }
+
+  const candidate = params as Record<string, unknown>;
+  const hasCursor = Object.prototype.hasOwnProperty.call(candidate, 'cursor');
+  const hasLimit = Object.prototype.hasOwnProperty.call(candidate, 'limit');
+
+  if (!hasCursor || !hasLimit) {
+    return false;
+  }
+
+  const cursor = candidate.cursor;
+  const limit = candidate.limit;
+
+  const isCursorValid = cursor === null || typeof cursor === 'string';
+  const isLimitValid = typeof limit === 'number';
+
+  return isCursorValid && isLimitValid;
+};
+
+const updateFeedListCache = (queryClient: QueryClient, feeds: Feed[]) => {
+  if (feeds.length === 0) {
+    return;
+  }
+
+  const queries = queryClient.getQueriesData<FeedListResponse>({ queryKey: FEEDS_QUERY_KEY });
+
+  queries.forEach(([queryKey, current]) => {
+    if (!current || !isFeedListQueryKey(queryKey)) {
+      return;
+    }
+
+    const [, params] = queryKey;
+    const limit = typeof params.limit === 'number' ? params.limit : current.meta.limit;
+    const isFirstPage = params.cursor === null;
+
+    const existingIds = new Set(current.items.map((item) => item.id));
+    const newFeeds = feeds.filter((feed) => !existingIds.has(feed.id));
+
+    if (newFeeds.length === 0) {
+      return;
+    }
+
+    const nextItems = isFirstPage ? [...newFeeds, ...current.items].slice(0, limit) : current.items;
+    const nextMeta = {
+      ...current.meta,
+      total: current.meta.total + newFeeds.length,
+    };
+
+    queryClient.setQueryData<FeedListResponse>(queryKey, {
+      ...current,
+      items: nextItems,
+      meta: nextMeta,
+    });
+  });
+};
 
 type FeedListParams = {
   cursor: string | null;
@@ -34,7 +122,8 @@ export const useCreateFeed = () => {
   const queryClient = useQueryClient();
   return useMutation<Feed, HttpError, { url: string; title?: string | null }>({
     mutationFn: (payload) => createFeed(payload),
-    onSuccess: () => {
+    onSuccess: (created) => {
+      updateFeedListCache(queryClient, [created]);
       queryClient.invalidateQueries({ queryKey: FEEDS_QUERY_KEY }).catch(() => {
         // ignore cache errors
       });
@@ -46,7 +135,8 @@ export const useBulkCreateFeeds = () => {
   const queryClient = useQueryClient();
   return useMutation<FeedBulkResult, HttpError, { urls: string[] }>({
     mutationFn: ({ urls }) => bulkCreateFeeds(urls),
-    onSuccess: () => {
+    onSuccess: (result) => {
+      updateFeedListCache(queryClient, result.created);
       queryClient.invalidateQueries({ queryKey: FEEDS_QUERY_KEY }).catch(() => {
         // ignore cache errors
       });


### PR DESCRIPTION
## Summary
- detect feed list query caches and update them when new feeds are created
- optimistically insert created feeds into cached lists before triggering refetches
- keep the existing invalidation flow so the UI stays in sync with the API

## Testing
- npm run type-check
- npm test -- src/pages/feeds/FeedsPage.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d0b62ac7688325a91524850040313e