### PR TITLE
Refine posts page flow and address sonar issues

### DIFF
--- a/backend/prisma.config.js
+++ b/backend/prisma.config.js
@@ -1,5 +1,5 @@
-const path = require('path');
-const fs = require('fs');
+const path = require('node:path');
+const fs = require('node:fs');
 const dotenv = require('dotenv');
 const { defineConfig } = require('prisma/config');
 
@@ -9,12 +9,12 @@ if (nodeEnv && nodeEnv.trim() !== '') {
   envFiles.push(`.env.${nodeEnv}`);
 }
 
-envFiles.forEach((relativePath) => {
+for (const relativePath of envFiles) {
   const absolutePath = path.resolve(__dirname, relativePath);
   if (fs.existsSync(absolutePath)) {
     dotenv.config({ path: absolutePath, override: process.env.PRISMA_FORCE_DIRECT !== '1' });
   }
-});
+}
 
 dotenv.config({ override: process.env.PRISMA_FORCE_DIRECT !== '1' });
 

--- a/backend/scripts/db-migrate-deploy-vercel.js
+++ b/backend/scripts/db-migrate-deploy-vercel.js
@@ -63,11 +63,11 @@ const parseConnectionString = (connectionString) => {
       connectionTimeoutMillis: 15000,
     };
 
-    url.searchParams.forEach((value, key) => {
+    for (const [key, value] of url.searchParams) {
       if (key === 'sslmode' && value === 'require') {
         config.ssl = { rejectUnauthorized: false };
       }
-    });
+    }
 
     return config;
   } catch (error) {

--- a/backend/scripts/generate-openapi.js
+++ b/backend/scripts/generate-openapi.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const openapiSpecification = require('../src/docs/openapi');
 
 const outputPath = path.resolve(__dirname, '../docs/openapi.json');

--- a/backend/scripts/run-task.js
+++ b/backend/scripts/run-task.js
@@ -1,5 +1,5 @@
 ﻿#!/usr/bin/env node
-const { spawn } = require('child_process');
+const { spawn } = require('node:child_process');
 
 const tasks = {
   dev: ['npm', ['run', 'dev']],

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const { config: loadEnv } = require('dotenv');
 const { z } = require('zod');
 
@@ -11,11 +11,11 @@ const envFiles = [
   path.resolve(process.cwd(), `.env.${envName}`),
 ];
 
-envFiles.forEach((filePath) => {
+for (const filePath of envFiles) {
   if (fs.existsSync(filePath)) {
     loadEnv({ path: filePath, override: true });
   }
-});
+}
 
 const toBoolean = (value, defaultValue = false) => {
   if (value === undefined) return defaultValue;
@@ -56,7 +56,7 @@ const envSchema = z.object({
     z.array(z.string().url()).nonempty()
   ),
   PAYLOAD_LIMIT: z.string().min(1).default('100kb'),
-  RATE_LIMIT_WINDOW_MS: z.preprocess((value) => toNumber(value, 60_000), z.number().int().positive()),
+  RATE_LIMIT_WINDOW_MS: z.preprocess((value) => toNumber(value, 60000), z.number().int().positive()),
   RATE_LIMIT_MAX: z.preprocess((value) => toNumber(value, 100), z.number().int().positive()),
   ENABLE_METRICS: z.preprocess((value) => toBoolean(value, true), z.boolean()),
   CACHE_MAX_AGE_SECONDS: z.preprocess((value) => toNumber(value, 60), z.number().int().nonnegative()),
@@ -69,7 +69,7 @@ const envSchema = z.object({
   GOOGLE_CLIENT_SECRET: z.string().min(1),
   GOOGLE_REDIRECT_URI: z.string().url(),
   SESSION_SECRET: z.string().min(16),
-  SESSION_TTL_SECONDS: z.preprocess((value) => toNumber(value, 3_600), z.number().int().positive()),
+  SESSION_TTL_SECONDS: z.preprocess((value) => toNumber(value, 3600), z.number().int().positive()),
   SESSION_RENEW_THRESHOLD_SECONDS: z.preprocess((value) => toNumber(value, 900), z.number().int().nonnegative()),
   SUPERADMIN_EMAIL: z.string().email(),
   SENTRY_DSN_BACKEND: z.string().optional().transform((value) => (value ? value.trim() : '')),

--- a/backend/src/docs/openapi.js
+++ b/backend/src/docs/openapi.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('node:path');
 const swaggerJsdoc = require('swagger-jsdoc');
 const config = require('../config');
 const { ROLES } = require('../constants/roles');

--- a/backend/src/middlewares/request-context.js
+++ b/backend/src/middlewares/request-context.js
@@ -1,4 +1,4 @@
-const { randomUUID } = require('crypto');
+const { randomUUID } = require('node:crypto');
 
 const attachRequestId = (req, res, next) => {
   const incomingId = req.headers['x-request-id'];

--- a/backend/src/schemas/posts.schema.js
+++ b/backend/src/schemas/posts.schema.js
@@ -1,8 +1,5 @@
 const { z } = require('zod');
-const postsService = require('../services/posts.service');
-
 const positiveInt = z.coerce.number().int().positive();
-const MAX_PAGE_SIZE = postsService.constants.MAX_PAGE_SIZE;
 
 const listPostsQuerySchema = z
   .object({

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,4 +1,4 @@
-const http = require('http');
+const http = require('node:http');
 
 const app = require('./app');
 const config = require('./config');
@@ -51,7 +51,7 @@ const gracefulShutdown = (signal) => {
     ]).finally(() => {
       process.exit(1);
     });
-  }, 10_000).unref();
+  }, 10000).unref();
 };
 
 process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));

--- a/backend/src/services/allowlist.service.js
+++ b/backend/src/services/allowlist.service.js
@@ -39,7 +39,7 @@ const listAllowedUsers = async ({ cursor, limit } = {}) => {
 
   const hasMore = entries.length > safeLimit;
   const items = hasMore ? entries.slice(0, safeLimit) : entries;
-  const nextCursor = hasMore ? items[items.length - 1].id : null;
+  const nextCursor = hasMore ? (items.at(-1)?.id ?? null) : null;
   const total = await allowlistRepository.countAll();
 
   return {

--- a/backend/tests/posts.e2e.test.js
+++ b/backend/tests/posts.e2e.test.js
@@ -78,15 +78,15 @@ describe('Posts API', () => {
       return null;
     });
 
-    originalFetch = global.fetch;
+    originalFetch = globalThis.fetch;
   });
 
   afterEach(() => {
     jest.clearAllMocks();
     if (originalFetch) {
-      global.fetch = originalFetch;
+      globalThis.fetch = originalFetch;
     } else {
-      delete global.fetch;
+      delete globalThis.fetch;
     }
   });
 
@@ -103,7 +103,7 @@ describe('Posts API', () => {
       const publishedAt = new Date(Date.now() - 60 * 1000);
       const rss = `<?xml version="1.0"?><rss version="2.0"><channel><title>Feed</title><item><title>Story</title><description>Snippet</description><pubDate>${publishedAt.toUTCString()}</pubDate><guid>guid-1</guid></item></channel></rss>`;
 
-      global.fetch = createFetchMock(rss);
+      globalThis.fetch = createFetchMock(rss);
 
       const response = await withAuth(
         TOKENS.user1,
@@ -112,7 +112,7 @@ describe('Posts API', () => {
         .expect('Content-Type', /json/)
         .expect(200);
 
-      expect(global.fetch).toHaveBeenCalledWith(feed.url, expect.any(Object));
+      expect(globalThis.fetch).toHaveBeenCalledWith(feed.url, expect.any(Object));
       expect(response.body.data.feeds).toHaveLength(1);
       expect(response.body.data.feeds[0]).toEqual(
         expect.objectContaining({
@@ -145,7 +145,7 @@ describe('Posts API', () => {
       const publishedAt = new Date(Date.now() - 2 * 60 * 1000);
       const rss = `<?xml version="1.0"?><rss version="2.0"><channel><title>Feed</title><item><title>Concurrent Story</title><description>Snippet</description><pubDate>${publishedAt.toUTCString()}</pubDate><guid>guid-concurrent</guid></item></channel></rss>`;
 
-      global.fetch = createDelayedFetchMock(rss);
+      globalThis.fetch = createDelayedFetchMock(rss);
 
       const requestA = withAuth(TOKENS.user1, request(app).post('/api/v1/posts/refresh')).expect('Content-Type', /json/);
       const requestB = withAuth(TOKENS.user1, request(app).post('/api/v1/posts/refresh')).expect('Content-Type', /json/);
@@ -155,7 +155,7 @@ describe('Posts API', () => {
 
       const [responseA, responseB] = await Promise.all([promiseA, promiseB]);
 
-      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
       expect(responseA.body.data).toEqual(responseB.body.data);
       expect(responseA.body.data.feeds[0].articlesCreated).toBe(1);
       const articles = await prisma.article.findMany();
@@ -231,9 +231,9 @@ describe('Posts API', () => {
         })
         .join('')}</channel></rss>`;
 
-      global.fetch = createFetchMock(rss);
+      globalThis.fetch = createFetchMock(rss);
 
-      await postsService.refreshUserFeeds({ ownerKey: '1', now, fetcher: global.fetch });
+      await postsService.refreshUserFeeds({ ownerKey: '1', now, fetcher: globalThis.fetch });
 
       const firstPage = await withAuth(
         TOKENS.user1,

--- a/backend/tests/posts.service.test.js
+++ b/backend/tests/posts.service.test.js
@@ -443,9 +443,9 @@ describe('posts.service', () => {
 
       const posts = await prisma.post.findMany();
       expect(posts).toHaveLength(3);
-      posts.forEach((post) => {
+      for (const post of posts) {
         expect(post.content).toBe(POST_PLACEHOLDER_CONTENT);
-      });
+      }
     });
 
     it('filters out articles older than seven days and supports feed filtering', async () => {

--- a/frontend/src/components/navigation/LanguageSwitcher.tsx
+++ b/frontend/src/components/navigation/LanguageSwitcher.tsx
@@ -14,7 +14,7 @@ export const LanguageSwitcher = () => {
   const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
     const nextLanguage = event.target.value;
 
-    const browserWindow = typeof globalThis.window === 'undefined' ? undefined : globalThis.window;
+    const browserWindow = 'window' in globalThis ? globalThis.window : undefined;
     browserWindow?.localStorage.setItem(LANGUAGE_STORAGE_KEY, nextLanguage);
 
     i18n.changeLanguage(nextLanguage).catch((err) => {
@@ -23,7 +23,7 @@ export const LanguageSwitcher = () => {
   };
 
   useEffect(() => {
-    const browserWindow = typeof globalThis.window === 'undefined' ? undefined : globalThis.window;
+    const browserWindow = 'window' in globalThis ? globalThis.window : undefined;
     if (!browserWindow) {
       return;
     }

--- a/frontend/src/components/navigation/ThemeToggle.tsx
+++ b/frontend/src/components/navigation/ThemeToggle.tsx
@@ -11,7 +11,7 @@ const stringToTheme = (value: string | null): Theme | null => {
 };
 
 const getInitialTheme = (): Theme => {
-  const browserWindow = typeof globalThis.window === 'undefined' ? undefined : globalThis.window;
+  const browserWindow = 'window' in globalThis ? globalThis.window : undefined;
   if (!browserWindow) {
     return 'light';
   }
@@ -25,11 +25,12 @@ const getInitialTheme = (): Theme => {
 };
 
 const applyTheme = (nextTheme: Theme) => {
-  if (typeof document === 'undefined') {
+  const rootDocument = 'document' in globalThis ? globalThis.document : undefined;
+  if (!rootDocument) {
     return;
   }
 
-  document.documentElement.dataset.theme = nextTheme;
+  rootDocument.documentElement.dataset.theme = nextTheme;
 };
 
 export const ThemeToggle = () => {
@@ -37,7 +38,7 @@ export const ThemeToggle = () => {
 
   useEffect(() => {
     applyTheme(theme);
-    const browserWindow = typeof globalThis.window === 'undefined' ? undefined : globalThis.window;
+    const browserWindow = 'window' in globalThis ? globalThis.window : undefined;
     browserWindow?.localStorage.setItem(STORAGE_KEY, theme);
   }, [theme]);
 

--- a/frontend/src/config/i18n.ts
+++ b/frontend/src/config/i18n.ts
@@ -555,7 +555,7 @@ const initialiseI18n = async () => {
 
 void initialiseI18n();
 
-export default i18n;
+export { default } from 'i18next';
 
 
 

--- a/frontend/src/features/auth/components/GoogleLoginButton.tsx
+++ b/frontend/src/features/auth/components/GoogleLoginButton.tsx
@@ -56,7 +56,9 @@ export const GoogleLoginButton: React.FC = () => {
 
   const onGoogleCredential = useCallback(
     (response: CredentialResponse) => {
-      void handleCredential(response);
+      handleCredential(response).catch((error) => {
+        console.error('Failed to process Google credential response.', error);
+      });
     },
     [handleCredential],
   );

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -89,7 +89,7 @@ const ErrorFallback: React.FC = () => (
         type="button"
         className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90"
         onClick={() => {
-          const browserWindow = typeof globalThis.window === 'undefined' ? undefined : globalThis.window;
+          const browserWindow = 'window' in globalThis ? globalThis.window : undefined;
           browserWindow?.location.reload();
         }}
       >

--- a/frontend/src/pages/allowlist/AllowlistPage.tsx
+++ b/frontend/src/pages/allowlist/AllowlistPage.tsx
@@ -153,8 +153,7 @@ export const AllowlistPage = () => {
                         if (entry.immutable) {
                           return;
                         }
-                        const browserWindow =
-                          typeof globalThis.window === 'undefined' ? undefined : globalThis.window;
+                        const browserWindow = 'window' in globalThis ? globalThis.window : undefined;
                         const confirmed =
                           browserWindow?.confirm(t('allowlist.table.removeConfirm', 'Remover este email da allowlist?')) ?? false;
                         if (!confirmed) {

--- a/frontend/src/pages/feeds/FeedsPage.test.tsx
+++ b/frontend/src/pages/feeds/FeedsPage.test.tsx
@@ -191,7 +191,7 @@ beforeEach(() => {
     createMutationResult<{ message: string }, number>(deleteMutate, { isPending: false }),
   );
 
-  const browserWindow = typeof globalThis.window === 'undefined' ? undefined : globalThis.window;
+  const browserWindow = 'window' in globalThis ? globalThis.window : undefined;
   if (!browserWindow) {
     throw new Error('window is not available for confirm spy');
   }

--- a/frontend/src/pages/feeds/FeedsPage.tsx
+++ b/frontend/src/pages/feeds/FeedsPage.tsx
@@ -368,7 +368,7 @@ const FeedsPage = () => {
     setListFeedback(null);
     setEditFeedback(null);
 
-    const browserWindow = typeof globalThis.window === 'undefined' ? undefined : globalThis.window;
+    const browserWindow = 'window' in globalThis ? globalThis.window : undefined;
     const confirmed = browserWindow?.confirm(t('feeds.list.deleteConfirm', 'Remover este feed?')) ?? false;
     if (!confirmed) {
       return;
@@ -630,7 +630,7 @@ const FeedsPage = () => {
     }
 
     const nextPrev = previousCursors.slice(0, -1);
-    const previous = previousCursors[previousCursors.length - 1] ?? null;
+    const previous = previousCursors.at(-1) ?? null;
     setPreviousCursors(nextPrev);
     setCursor(previous);
   };


### PR DESCRIPTION
## Summary
- refactor the Posts page to delegate list rendering to a dedicated component and simplify pagination/error handling
- replace legacy browser detection logic with safer globalThis guards and adjust tests accordingly
- update backend services, scripts, and tests to satisfy static analysis by using modern node:* imports, Sets/for-of loops, replaceAll, and TypeError for invalid inputs

## Testing
- npm run lint (frontend)
- npm run lint (backend)


------
https://chatgpt.com/codex/tasks/task_e_68d1566531988325940fed54110918d8