### PR TITLE
Refine posts page state handling and clean lint warnings

### DIFF
--- a/backend/src/controllers/feed.controller.js
+++ b/backend/src/controllers/feed.controller.js
@@ -3,11 +3,13 @@ const ApiError = require('../utils/api-error');
 const feedService = require('../services/feed.service');
 
 const getOwnerKey = (req) => {
-  if (!req.user || req.user.id == null) {
+  const { user } = req;
+
+  if (user == null || user.id == null) {
     throw new ApiError({ statusCode: 401, code: 'UNAUTHENTICATED', message: 'Authentication required' });
   }
 
-  return String(req.user.id);
+  return String(user.id);
 };
 
 const mapFeed = (feed) => ({

--- a/backend/src/vercel.js
+++ b/backend/src/vercel.js
@@ -1,7 +1,7 @@
 const app = require('./app');
 const { ensureAppBootstrapped } = require('./startup');
 
-module.exports = async (req, res) => {
+const vercelHandler = async (req, res) => {
   try {
     await ensureAppBootstrapped();
     return app(req, res);
@@ -12,3 +12,5 @@ module.exports = async (req, res) => {
     res.end(JSON.stringify({ success: false, error: { message: 'Internal Server Error' } }));
   }
 };
+
+module.exports = vercelHandler;


### PR DESCRIPTION
## Summary
- simplify the posts page expanded section update logic by moving it into a helper function
- adjust the owner key retrieval to avoid negated conditions
- name the Vercel entrypoint handler for clearer stack traces and lint compliance

## Testing
- npm run lint (frontend)
- npm run lint (backend)

------
https://chatgpt.com/codex/tasks/task_e_68d194c1a3188325b1ee6bccea893f49