### PR TITLE
feat: add feed normalization layer

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,6 +20,7 @@
                 "express-rate-limit": "^8.1.0",
                 "fast-xml-parser": "^4.5.1",
                 "google-auth-library": "^9.15.1",
+                "he": "^1.2.0",
                 "helmet": "^8.1.0",
                 "hpp": "^0.2.3",
                 "morgan": "^1.10.1",
@@ -4045,6 +4046,15 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/he": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+            "license": "MIT",
+            "bin": {
+                "he": "bin/he"
             }
         },
         "node_modules/helmet": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -39,6 +39,7 @@
         "express-rate-limit": "^8.1.0",
         "fast-xml-parser": "^4.5.1",
         "google-auth-library": "^9.15.1",
+        "he": "^1.2.0",
         "helmet": "^8.1.0",
         "hpp": "^0.2.3",
         "morgan": "^1.10.1",

--- a/backend/src/lib/feed-normalizer.js
+++ b/backend/src/lib/feed-normalizer.js
@@ -1,0 +1,472 @@
+const he = require('he');
+
+const TEXT_NODE_KEYS = ['#text', '_text', 'text', 'value'];
+
+const ensureArray = (value) => {
+  if (value == null) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+};
+
+const coerceToString = (value) => {
+  if (value == null) {
+    return undefined;
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  return undefined;
+};
+
+const extractFirstText = (value) => {
+  const direct = coerceToString(value);
+  if (direct != null) {
+    return direct;
+  }
+
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const text = extractFirstText(entry);
+      if (text != null && text !== '') {
+        return text;
+      }
+    }
+    return undefined;
+  }
+
+  if (value && typeof value === 'object') {
+    for (const key of TEXT_NODE_KEYS) {
+      if (Object.hasOwn(value, key)) {
+        const text = extractFirstText(value[key]);
+        if (text != null && text !== '') {
+          return text;
+        }
+      }
+    }
+  }
+
+  return undefined;
+};
+
+const decodeAndTrim = (value) => {
+  const raw = extractFirstText(value);
+  if (typeof raw !== 'string') {
+    return undefined;
+  }
+  const decoded = he.decode(raw, { isAttributeValue: false });
+  const trimmed = decoded.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const getRawHtml = (value) => {
+  const raw = extractFirstText(value);
+  return typeof raw === 'string' ? raw : undefined;
+};
+
+const parseBooleanAttribute = (value) => {
+  if (value == null) {
+    return undefined;
+  }
+
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  const normalized = String(value).trim().toLowerCase();
+  if (normalized === 'true' || normalized === '1' || normalized === 'yes') {
+    return true;
+  }
+  if (normalized === 'false' || normalized === '0' || normalized === 'no') {
+    return false;
+  }
+
+  return undefined;
+};
+
+const parseNumberAttribute = (value) => {
+  if (value == null) {
+    return undefined;
+  }
+
+  const numberValue = Number.parseInt(String(value).trim(), 10);
+  return Number.isNaN(numberValue) ? undefined : numberValue;
+};
+
+const decodeUrl = (value) => {
+  const raw = extractFirstText(value);
+  if (typeof raw !== 'string') {
+    return undefined;
+  }
+  const decoded = he.decode(raw, { isAttributeValue: true });
+  const trimmed = decoded.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const extractAtomLink = (links) => {
+  const entries = ensureArray(links);
+  let fallback;
+
+  for (const entry of entries) {
+    if (!entry) {
+      continue;
+    }
+
+    if (typeof entry === 'string') {
+      const url = decodeUrl(entry);
+      if (url && !fallback) {
+        fallback = url;
+      }
+      continue;
+    }
+
+    if (typeof entry === 'object') {
+      const relRaw = entry['@_rel'] ?? entry.rel;
+      const rel = typeof relRaw === 'string' ? relRaw.trim().toLowerCase() : undefined;
+      const href = decodeUrl(entry['@_href'] ?? entry.href ?? entry);
+
+      if (!href) {
+        continue;
+      }
+
+      if (rel === 'alternate') {
+        return href;
+      }
+
+      if (!fallback && !rel) {
+        fallback = href;
+      }
+
+      if (!fallback && rel === 'self') {
+        fallback = href;
+      }
+    }
+  }
+
+  return fallback;
+};
+
+const resolveCanonicalUrl = (item) => {
+  const origLink = decodeUrl(item['feedburner:origLink']);
+  if (origLink) {
+    return origLink;
+  }
+
+  const link = item.link;
+  if (link && typeof link === 'object' && (link['@_href'] || Array.isArray(link))) {
+    const atomLink = extractAtomLink(link);
+    if (atomLink) {
+      return atomLink;
+    }
+  }
+
+  const stringLink = decodeUrl(link);
+  if (stringLink) {
+    return stringLink;
+  }
+
+  return undefined;
+};
+
+const formatPublishedDate = (item) => {
+  const candidates = [item.pubDate, item.published, item.updated];
+
+  for (const candidate of candidates) {
+    const text = extractFirstText(candidate);
+    if (!text) {
+      continue;
+    }
+
+    const date = new Date(text);
+    if (!Number.isNaN(date.valueOf())) {
+      return date.toISOString().slice(0, 10);
+    }
+  }
+
+  return undefined;
+};
+
+const extractAuthor = (item) => {
+  const creator = decodeAndTrim(item['dc:creator']);
+  if (creator) {
+    return creator;
+  }
+
+  const atomAuthor = item.author;
+  if (atomAuthor && typeof atomAuthor === 'object') {
+    const name = decodeAndTrim(atomAuthor.name);
+    if (name) {
+      return name;
+    }
+  }
+
+  const author = decodeAndTrim(item.author);
+  return author ?? undefined;
+};
+
+const collectCategoryStrings = (value) => {
+  const result = [];
+
+  if (value == null) {
+    return result;
+  }
+
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    result.push(String(value));
+    return result;
+  }
+
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      result.push(...collectCategoryStrings(entry));
+    }
+    return result;
+  }
+
+  if (typeof value === 'object') {
+    if (typeof value['@_term'] === 'string') {
+      result.push(value['@_term']);
+    }
+    if (typeof value['@_label'] === 'string') {
+      result.push(value['@_label']);
+    }
+    if (typeof value['@_scheme'] === 'string') {
+      result.push(value['@_scheme']);
+    }
+
+    for (const key of TEXT_NODE_KEYS) {
+      if (Object.hasOwn(value, key)) {
+        result.push(...collectCategoryStrings(value[key]));
+      }
+    }
+  }
+
+  return result;
+};
+
+const normalizeCategories = (item) => {
+  const rawCategories = [item.category, item.categories, item['dc:subject']];
+  const deduped = new Map();
+
+  for (const candidate of rawCategories) {
+    const values = collectCategoryStrings(candidate);
+    for (const value of values) {
+      const decoded = he.decode(String(value), { isAttributeValue: false }).trim();
+      if (!decoded) {
+        continue;
+      }
+      const key = decoded.toLowerCase();
+      if (!deduped.has(key)) {
+        deduped.set(key, decoded);
+      }
+    }
+  }
+
+  return Array.from(deduped.values());
+};
+
+const buildRawHtmlCandidates = (item) => ({
+  contentEncoded: getRawHtml(item['content:encoded']),
+  content: getRawHtml(item.content),
+  descriptionOrSummary: getRawHtml(item.description ?? item.summary),
+});
+
+const parseMediaResource = (entry) => {
+  if (!entry || typeof entry !== 'object') {
+    return undefined;
+  }
+
+  const url = decodeUrl(entry['@_url'] ?? entry.url);
+  if (!url) {
+    return undefined;
+  }
+
+  const width = parseNumberAttribute(entry['@_width'] ?? entry.width);
+  const height = parseNumberAttribute(entry['@_height'] ?? entry.height);
+
+  const resource = { url };
+  if (width != null) {
+    resource.width = width;
+  }
+  if (height != null) {
+    resource.height = height;
+  }
+
+  return resource;
+};
+
+const collectMediaResources = (value) => {
+  const resources = [];
+  for (const entry of ensureArray(value)) {
+    const parsed = parseMediaResource(entry);
+    if (parsed) {
+      resources.push(parsed);
+    }
+  }
+  return resources;
+};
+
+const selectEnclosureImage = (value) => {
+  for (const entry of ensureArray(value)) {
+    if (!entry || typeof entry !== 'object') {
+      continue;
+    }
+    const type = decodeAndTrim(entry['@_type'] ?? entry.type);
+    if (!type || !type.toLowerCase().startsWith('image/')) {
+      continue;
+    }
+    const url = decodeUrl(entry['@_url'] ?? entry.url);
+    if (!url) {
+      continue;
+    }
+    return { url, type };
+  }
+  return undefined;
+};
+
+const IMG_SRC_REGEX = /<img\b[^>]*?\bsrc\s*=\s*("([^"]+)"|'([^']+)'|([^"'\s>]+))/gi;
+
+const collectInlineImages = (candidates) => {
+  const deduped = new Map();
+
+  for (const html of candidates) {
+    if (typeof html !== 'string') {
+      continue;
+    }
+
+    let match;
+    while ((match = IMG_SRC_REGEX.exec(html)) != null) {
+      const rawSrc = match[2] ?? match[3] ?? match[4];
+      if (!rawSrc) {
+        continue;
+      }
+      const decoded = he.decode(rawSrc, { isAttributeValue: true }).trim();
+      if (!decoded) {
+        continue;
+      }
+      const key = decoded;
+      if (!deduped.has(key)) {
+        deduped.set(key, decoded);
+      }
+    }
+  }
+
+  return Array.from(deduped.values());
+};
+
+const buildMediaObject = (item, rawHtmlCandidates) => {
+  const mediaContent = collectMediaResources(item['media:content']);
+  const mediaThumbnail = collectMediaResources(item['media:thumbnail']);
+  const enclosureImage = selectEnclosureImage(item.enclosure);
+  const inlineImages = collectInlineImages([
+    rawHtmlCandidates.contentEncoded,
+    rawHtmlCandidates.content,
+    rawHtmlCandidates.descriptionOrSummary,
+  ]);
+
+  const media = {};
+  if (mediaContent.length > 0) {
+    media.mediaContent = mediaContent;
+  }
+  if (mediaThumbnail.length > 0) {
+    media.mediaThumbnail = mediaThumbnail;
+  }
+  if (enclosureImage) {
+    media.enclosureImage = enclosureImage;
+  }
+  if (inlineImages.length > 0) {
+    media.inlineImages = inlineImages;
+  }
+
+  return Object.keys(media).length > 0 ? media : undefined;
+};
+
+const extractGuid = (item) => {
+  const guidRaw = item.guid;
+  const guid = decodeAndTrim(guidRaw);
+  const isPermaLink = parseBooleanAttribute(
+    guidRaw && typeof guidRaw === 'object' ? guidRaw['@_isPermaLink'] ?? guidRaw.isPermaLink : undefined,
+  );
+
+  if (!guid && isPermaLink === undefined) {
+    return undefined;
+  }
+
+  const result = {};
+  if (guid) {
+    result.guid = guid;
+  }
+  if (isPermaLink !== undefined) {
+    result.isPermaLink = isPermaLink;
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+};
+
+/**
+ * Normalizes a parsed feed entry (RSS 2.0, Atom 1.0 or RSS 1.0/RDF) into a standard shape.
+ *
+ * @param {object} rawItem - Item produced by the XML parser used by the feed fetcher.
+ * @param {object} [options]
+ * @param {string} [options.feedUrl] - URL of the source feed, if available in the context.
+ * @param {{ warn?: Function }} [options.logger] - Optional logger used for soft warnings.
+ * @returns {object} Normalized feed item containing title, canonicalUrl, publication date, author,
+ * categories, raw HTML candidates, media metadata, optional GUID information and source feed.
+ */
+const normalizeFeedItem = (rawItem, options = {}) => {
+  if (!rawItem || typeof rawItem !== 'object') {
+    throw new TypeError('rawItem must be an object');
+  }
+
+  const { feedUrl, logger = console } = options;
+
+  const title = decodeAndTrim(rawItem.title) ?? '';
+  const canonicalUrl = resolveCanonicalUrl(rawItem);
+  const publishedAtISO = formatPublishedDate(rawItem);
+  const author = extractAuthor(rawItem);
+  const categories = normalizeCategories(rawItem);
+  const rawHtmlCandidates = buildRawHtmlCandidates(rawItem);
+  const media = buildMediaObject(rawItem, rawHtmlCandidates);
+  const guidInfo = extractGuid(rawItem);
+
+  if (!title && logger?.warn) {
+    logger.warn('Feed item missing title', { feedUrl, guid: guidInfo?.guid ?? null });
+  }
+
+  if (!canonicalUrl && logger?.warn) {
+    logger.warn('Feed item missing canonical URL', { feedUrl, guid: guidInfo?.guid ?? null });
+  }
+
+  const normalized = {
+    title,
+    canonicalUrl,
+    publishedAtISO,
+    author,
+    categories,
+    rawHtmlCandidates,
+  };
+
+  if (media) {
+    normalized.media = media;
+  }
+
+  if (guidInfo) {
+    Object.assign(normalized, guidInfo);
+  }
+
+  if (feedUrl) {
+    normalized.sourceFeed = { url: feedUrl };
+  }
+
+  return normalized;
+};
+
+module.exports = {
+  normalizeFeedItem,
+};
+

--- a/backend/tests/fixtures/atom-example.xml
+++ b/backend/tests/fixtures/atom-example.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Example Atom Feed</title>
+  <entry>
+    <title>Orbital Mechanics Explained</title>
+    <id>tag:example.com,2025-02-10:/orbital-mechanics-explained</id>
+    <updated>2025-02-10T08:00:00Z</updated>
+    <published>2025-02-09T23:00:00Z</published>
+    <link rel="alternate" type="text/html" href="https://example.com/orbital-mechanics-explained" />
+    <link rel="self" href="https://example.com/atom.xml" />
+    <summary type="html">&lt;p&gt;Learn about orbits.&lt;/p&gt;</summary>
+    <content type="html">
+      &lt;p&gt;Full article body&lt;/p&gt;
+      &lt;p&gt;&lt;img src="https://example.com/images/orbit.png" alt="orbit" /&gt;&lt;/p&gt;
+    </content>
+    <author>
+      <name>Alex Johnson</name>
+    </author>
+    <category term="Science" label="Science" />
+  </entry>
+</feed>

--- a/backend/tests/fixtures/rss-404media.xml
+++ b/backend/tests/fixtures/rss-404media.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+  xmlns:content="http://purl.org/rss/1.0/modules/content/"
+  xmlns:media="http://search.yahoo.com/mrss/"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:feedburner="http://rssnamespace.org/feedburner/ext/1.0">
+  <channel>
+    <title>404 Media</title>
+    <item>
+      <title><![CDATA[Inside the &quot;Example&quot; Conspiracy]]></title>
+      <link>https://www.404media.co/inside-the-example-conspiracy/</link>
+      <feedburner:origLink>https://www.404media.co/inside-the-example-conspiracy/</feedburner:origLink>
+      <guid isPermaLink="false">tag:404media.co,2025-01-01:/inside-the-example-conspiracy</guid>
+      <pubDate>Wed, 01 Jan 2025 10:00:00 +0000</pubDate>
+      <dc:creator><![CDATA[404 Media Team]]></dc:creator>
+      <category><![CDATA[Investigations]]></category>
+      <category><![CDATA[Technology]]></category>
+      <description><![CDATA[<p>A short summary for the story.</p>]]></description>
+      <content:encoded><![CDATA[
+        <p>The long-form story body.</p>
+        <figure><img src="https://static.404media.co/images/story-main.jpg" width="1600" height="900" /></figure>
+      ]]></content:encoded>
+      <media:content url="https://static.404media.co/images/story-main.jpg" width="1600" height="900" medium="image" />
+      <media:thumbnail url="https://static.404media.co/images/story-thumb.jpg" width="800" height="450" />
+    </item>
+  </channel>
+</rss>

--- a/backend/tests/fixtures/rss-substack.xml
+++ b/backend/tests/fixtures/rss-substack.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+  xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <title>Example Substack</title>
+    <item>
+      <title>Understanding Machine Learning</title>
+      <link>https://magazine.sebastianraschka.com/p/understanding-machine-learning</link>
+      <guid isPermaLink="false">substack-article-12345</guid>
+      <pubDate>Mon, 03 Feb 2025 15:30:00 +0000</pubDate>
+      <author><![CDATA[Sebastian Raschka]]></author>
+      <category><![CDATA[Data Science]]></category>
+      <description><![CDATA[Short intro &amp; highlights.]]></description>
+      <content:encoded><![CDATA[
+        <p>Hello readers!</p>
+        <p>Here is some content.</p>
+      ]]></content:encoded>
+      <enclosure url="https://substackcdn.com/image.jpg" length="0" type="image/jpeg" />
+    </item>
+  </channel>
+</rss>

--- a/backend/tests/fixtures/rss-wordpress.xml
+++ b/backend/tests/fixtures/rss-wordpress.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+  xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <title>Cloudflare Blog</title>
+    <item>
+      <title><![CDATA[Cloudflare launches new feature]]></title>
+      <link>https://blog.cloudflare.com/cloudflare-launches-new-feature/</link>
+      <pubDate>Thu, 06 Mar 2025 18:45:00 +0000</pubDate>
+      <guid isPermaLink="false">https://blog.cloudflare.com/?p=123456</guid>
+      <content:encoded><![CDATA[
+        <p>Launch day!</p>
+        <p><img src="https://blog.cloudflare.com/images/launch.png" alt="launch" /></p>
+      ]]></content:encoded>
+      <description><![CDATA[<p>Launch day!</p>]]></description>
+    </item>
+  </channel>
+</rss>

--- a/backend/tests/lib/feed-normalizer.test.js
+++ b/backend/tests/lib/feed-normalizer.test.js
@@ -1,0 +1,113 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { XMLParser } = require('fast-xml-parser');
+
+const { normalizeFeedItem } = require('../../src/lib/feed-normalizer');
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: '@_',
+  textNodeName: '#text',
+  trimValues: false,
+  parseTagValue: false,
+});
+
+const loadFixture = (name) =>
+  fs.readFileSync(path.join(__dirname, '..', 'fixtures', name), 'utf8');
+
+const getFirstItem = (parsed) => {
+  if (parsed.rss?.channel?.item) {
+    return Array.isArray(parsed.rss.channel.item)
+      ? parsed.rss.channel.item[0]
+      : parsed.rss.channel.item;
+  }
+  if (parsed.channel?.item) {
+    return Array.isArray(parsed.channel.item) ? parsed.channel.item[0] : parsed.channel.item;
+  }
+  if (parsed.feed?.entry) {
+    return Array.isArray(parsed.feed.entry) ? parsed.feed.entry[0] : parsed.feed.entry;
+  }
+  if (parsed.entry) {
+    return Array.isArray(parsed.entry) ? parsed.entry[0] : parsed.entry;
+  }
+  throw new Error('Unable to locate first feed item in fixture');
+};
+
+describe('normalizeFeedItem', () => {
+  it('normalizes a 404 Media RSS item with media content and metadata', () => {
+    const xml = loadFixture('rss-404media.xml');
+    const parsed = parser.parse(xml);
+    const item = getFirstItem(parsed);
+
+    const normalized = normalizeFeedItem(item, {
+      feedUrl: 'https://www.404media.co/rss/',
+    });
+
+    expect(normalized.title).toBe('Inside the "Example" Conspiracy');
+    expect(normalized.canonicalUrl).toBe('https://www.404media.co/inside-the-example-conspiracy/');
+    expect(normalized.publishedAtISO).toBe('2025-01-01');
+    expect(normalized.author).toBe('404 Media Team');
+    expect(normalized.categories).toEqual(['Investigations', 'Technology']);
+    expect(normalized.rawHtmlCandidates.contentEncoded).toContain('The long-form story body.');
+    expect(normalized.rawHtmlCandidates.descriptionOrSummary).toContain('A short summary');
+    expect(normalized.media).toBeDefined();
+    expect(normalized.media.mediaContent[0]).toEqual({
+      url: 'https://static.404media.co/images/story-main.jpg',
+      width: 1600,
+      height: 900,
+    });
+    expect(normalized.media.mediaThumbnail[0]).toEqual({
+      url: 'https://static.404media.co/images/story-thumb.jpg',
+      width: 800,
+      height: 450,
+    });
+    expect(normalized.guid).toBe('tag:404media.co,2025-01-01:/inside-the-example-conspiracy');
+    expect(normalized.isPermaLink).toBe(false);
+    expect(normalized.sourceFeed).toEqual({ url: 'https://www.404media.co/rss/' });
+  });
+
+  it('keeps enclosure image and author details for Substack RSS feeds', () => {
+    const xml = loadFixture('rss-substack.xml');
+    const parsed = parser.parse(xml);
+    const item = getFirstItem(parsed);
+
+    const normalized = normalizeFeedItem(item);
+
+    expect(normalized.rawHtmlCandidates.contentEncoded).toContain('Hello readers!');
+    expect(normalized.media.enclosureImage).toEqual({
+      url: 'https://substackcdn.com/image.jpg',
+      type: 'image/jpeg',
+    });
+    expect(normalized.author).toBe('Sebastian Raschka');
+    expect(normalized.categories).toEqual(['Data Science']);
+    expect(normalized.publishedAtISO).toBe('2025-02-03');
+  });
+
+  it('prefers alternate link and summary fields for Atom entries', () => {
+    const xml = loadFixture('atom-example.xml');
+    const parsed = parser.parse(xml);
+    const item = getFirstItem(parsed);
+
+    const normalized = normalizeFeedItem(item);
+
+    expect(normalized.canonicalUrl).toBe('https://example.com/orbital-mechanics-explained');
+    expect(normalized.rawHtmlCandidates.descriptionOrSummary).toBe('<p>Learn about orbits.</p>');
+    expect(normalized.rawHtmlCandidates.content).toContain('Full article body');
+    expect(normalized.media.inlineImages).toContain('https://example.com/images/orbit.png');
+    expect(normalized.publishedAtISO).toBe('2025-02-09');
+  });
+
+  it('extracts inline images from WordPress RSS feeds', () => {
+    const xml = loadFixture('rss-wordpress.xml');
+    const parsed = parser.parse(xml);
+    const item = getFirstItem(parsed);
+
+    const normalized = normalizeFeedItem(item);
+
+    expect(normalized.rawHtmlCandidates.contentEncoded).toContain('<img src="https://blog.cloudflare.com/images/launch.png"');
+    expect(normalized.media.inlineImages).toEqual(['https://blog.cloudflare.com/images/launch.png']);
+    expect(normalized.guid).toBe('https://blog.cloudflare.com/?p=123456');
+    expect(normalized.isPermaLink).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable feed item normalizer that unifies title, URL, dates, HTML, and media extraction for RSS/Atom entries
- capture representative feed fixtures and tests to validate the normalizer against 404 Media, Substack, Atom, and WordPress examples
- depend on `he` for HTML entity decoding used during normalization

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2d41bd82c832593d710fc50070fdc