### PR TITLE
Add body and lead selection heuristic

### DIFF
--- a/backend/src/lib/body-lead-selector.js
+++ b/backend/src/lib/body-lead-selector.js
@@ -1,0 +1,438 @@
+const he = require('he');
+
+const SOURCE_PRIORITY = ['contentEncoded', 'content', 'descriptionOrSummary'];
+const BLOCK_TAG_REGEX = /<(p|div|img|h1|h2|h3|ul|ol|li|figure|pre|code|blockquote)\b/i;
+const PARAGRAPH_REGEX = /<(p|figure)\b[^>]*>/gi;
+const HTML_LIKE_REGEX = /<\/?[a-z][^>]*>/i;
+const TAG_OR_ENTITY_REGEX = /(<[^>]+>|&[a-z0-9#]+;)/gi;
+const VOID_TAGS = new Set([
+  'area',
+  'base',
+  'br',
+  'col',
+  'embed',
+  'hr',
+  'img',
+  'input',
+  'link',
+  'meta',
+  'param',
+  'source',
+  'track',
+  'wbr',
+]);
+const BODY_SIZE_LIMIT = 150 * 1024; // 150 KB approx.
+const LEAD_TEXT_LIMIT = 400;
+
+const BLOCK_CLOSING_TAGS = ['</p>', '</div>', '</section>', '</article>', '</li>', '</ul>', '</ol>', '</figure>', '</pre>', '</code>', '</blockquote>'];
+
+const isNonEmptyString = (value) => typeof value === 'string' && value.trim().length > 0;
+
+const looksLikeHtml = (value) => HTML_LIKE_REGEX.test(value);
+
+const wrapPlainText = (value) => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return '';
+  }
+  return `<p>${trimmed}</p>`;
+};
+
+const removeTrivialBoilerplate = (html) => {
+  let result = html;
+
+  result = result.replace(
+    /<div[^>]*class="[^"]*\boutpost-pub-container\b[^"]*"[^>]*>[\s\S]*?<\/div>/gi,
+    '',
+  );
+
+  result = result.replace(
+    /(?:\s*<p[^>]*>\s*(?:<a[^>]*>\s*)?(?:read more|continue reading)[^<]*?(?:<\/a>)?\s*<\/p>\s*)+$/gim,
+    '',
+  );
+
+  return result;
+};
+
+const countParagraphs = (html) => {
+  const matches = html.match(PARAGRAPH_REGEX);
+  return matches ? matches.length : 0;
+};
+
+const hasBlockTags = (html) => BLOCK_TAG_REGEX.test(html);
+
+const computeLengthScore = (length) => Math.min(0.3, length * 0.0005);
+
+const computeContentScore = ({ hasBlocks, length, paragraphCount }) => {
+  const blockScore = hasBlocks ? 0.4 : 0;
+  const lengthScore = length > 0 ? computeLengthScore(length) : 0;
+  const paragraphScore = paragraphCount >= 2 ? 0.3 : 0;
+  return Math.min(1, blockScore + lengthScore + paragraphScore);
+};
+
+const tokenizeHtml = (html) => {
+  const tokens = [];
+  let lastIndex = 0;
+  let match;
+
+  while ((match = TAG_OR_ENTITY_REGEX.exec(html)) !== null) {
+    if (match.index > lastIndex) {
+      tokens.push({ type: 'text', value: html.slice(lastIndex, match.index) });
+    }
+
+    const token = match[0];
+    if (token.startsWith('<')) {
+      tokens.push({ type: 'tag', value: token });
+    } else {
+      tokens.push({ type: 'entity', value: token });
+    }
+
+    lastIndex = TAG_OR_ENTITY_REGEX.lastIndex;
+  }
+
+  if (lastIndex < html.length) {
+    tokens.push({ type: 'text', value: html.slice(lastIndex) });
+  }
+
+  return tokens;
+};
+
+const updateTagStack = (tag, stack) => {
+  const tagNameMatch = tag.match(/^<\/?\s*([a-z0-9:-]+)/i);
+  if (!tagNameMatch) {
+    return;
+  }
+
+  const tagName = tagNameMatch[1].toLowerCase();
+  if (tag.startsWith('</')) {
+    for (let i = stack.length - 1; i >= 0; i -= 1) {
+      if (stack[i] === tagName) {
+        stack.splice(i, 1);
+        break;
+      }
+    }
+    return;
+  }
+
+  if (VOID_TAGS.has(tagName)) {
+    return;
+  }
+
+  if (tag.endsWith('/>')) {
+    return;
+  }
+
+  stack.push(tagName);
+};
+
+const closeOpenTags = (html) => {
+  const tokens = tokenizeHtml(html);
+  const stack = [];
+
+  for (const token of tokens) {
+    if (token.type === 'tag') {
+      updateTagStack(token.value, stack);
+    }
+  }
+
+  if (stack.length === 0) {
+    return html;
+  }
+
+  let closed = html;
+  for (let i = stack.length - 1; i >= 0; i -= 1) {
+    closed += `</${stack[i]}>`;
+  }
+  return closed;
+};
+
+const truncateHtmlByTextLength = (html, limit) => {
+  if (!html) {
+    return { html: '', truncated: false };
+  }
+
+  const tokens = tokenizeHtml(html);
+  let length = 0;
+  let truncated = false;
+  let result = '';
+  const stack = [];
+
+  outer: for (const token of tokens) {
+    if (token.type === 'tag') {
+      result += token.value;
+      updateTagStack(token.value, stack);
+      continue;
+    }
+
+    if (token.type === 'entity') {
+      if (length >= limit) {
+        truncated = true;
+        break;
+      }
+      result += token.value;
+      length += 1;
+      continue;
+    }
+
+    const chars = Array.from(token.value);
+    for (const char of chars) {
+      if (length >= limit) {
+        truncated = true;
+        break outer;
+      }
+      result += char;
+      length += 1;
+    }
+  }
+
+  if (!truncated) {
+    return { html, truncated: false };
+  }
+
+  result = result.replace(/\s+$/, '');
+  result += '…';
+
+  for (let i = stack.length - 1; i >= 0; i -= 1) {
+    result += `</${stack[i]}>`;
+  }
+
+  return { html: result, truncated: true };
+};
+
+const truncateBodyHtml = (html) => {
+  if (!html || html.length <= BODY_SIZE_LIMIT) {
+    return { html, truncated: false };
+  }
+
+  let cutIndex = -1;
+  for (const closing of BLOCK_CLOSING_TAGS) {
+    const idx = html.lastIndexOf(closing, BODY_SIZE_LIMIT);
+    if (idx !== -1) {
+      const candidate = idx + closing.length;
+      if (candidate > cutIndex) {
+        cutIndex = candidate;
+      }
+    }
+  }
+
+  if (cutIndex === -1) {
+    cutIndex = BODY_SIZE_LIMIT;
+  }
+
+  let sliced = html.slice(0, cutIndex);
+
+  const partial = sliced.match(/<[^>]*$/);
+  if (partial && !partial[0].includes('>')) {
+    sliced = sliced.slice(0, partial.index);
+  }
+
+  return { html: closeOpenTags(sliced), truncated: true };
+};
+
+const normalizeForComparison = (html) => {
+  if (!html) {
+    return '';
+  }
+  const withoutTags = html.replace(/<[^>]*>/g, ' ');
+  const decoded = he.decode(withoutTags, { isAttributeValue: false });
+  return decoded.replace(/\s+/g, ' ').trim().toLowerCase();
+};
+
+const computeDedupeRatio = (a, b) => {
+  if (!a || !b) {
+    return 0;
+  }
+
+  if (a === b) {
+    return 1;
+  }
+
+  const tokensA = new Set(a.split(/\s+/).filter(Boolean));
+  const tokensB = new Set(b.split(/\s+/).filter(Boolean));
+
+  if (tokensA.size === 0 || tokensB.size === 0) {
+    return 0;
+  }
+
+  let intersection = 0;
+  for (const token of tokensA) {
+    if (tokensB.has(token)) {
+      intersection += 1;
+    }
+  }
+
+  const union = new Set([...tokensA, ...tokensB]).size;
+  return union === 0 ? 0 : intersection / union;
+};
+
+const addReason = (reasons, reason) => {
+  if (!reasons.includes(reason)) {
+    reasons.push(reason);
+  }
+};
+
+const evaluateCandidate = (source, value) => {
+  if (!isNonEmptyString(value)) {
+    return null;
+  }
+
+  let processed = value;
+  const trimmedOriginal = processed.trim();
+  let usedPlainTextWrapper = false;
+
+  if (!looksLikeHtml(trimmedOriginal)) {
+    processed = wrapPlainText(trimmedOriginal);
+    usedPlainTextWrapper = true;
+  }
+
+  const cleaned = removeTrivialBoilerplate(processed);
+  const trimmed = cleaned.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const hasBlocks = hasBlockTags(trimmed);
+  const paragraphCount = countParagraphs(trimmed);
+  const length = trimmed.length;
+  const contentScore = computeContentScore({ hasBlocks, length, paragraphCount });
+  const isSubstantial = hasBlocks || length > 300 || paragraphCount >= 2;
+
+  return {
+    source,
+    html: trimmed,
+    metrics: {
+      hasBlocks,
+      paragraphCount,
+      length,
+      contentScore,
+      isSubstantial,
+    },
+    usedPlainTextWrapper,
+    removedBoilerplate: cleaned !== processed,
+  };
+};
+
+/**
+ * Selects the best raw HTML body and optional lead from normalized feed candidates.
+ *
+ * @param {object} normalizedItem - Normalized feed item.
+ * @param {object} normalizedItem.rawHtmlCandidates - Available raw HTML candidates.
+ * @returns {{ bodyHtmlRaw: string, leadHtmlRaw: string | null, diagnostics: { chosenSource: 'contentEncoded' | 'content' | 'descriptionOrSummary' | 'empty', contentScore: number, leadUsed: boolean, dedupeRatio: number, reasons: string[] }}}
+ */
+const selectBodyAndLead = (normalizedItem) => {
+  if (!normalizedItem || typeof normalizedItem !== 'object') {
+    throw new TypeError('normalizedItem must be an object');
+  }
+
+  const candidates = normalizedItem.rawHtmlCandidates || {};
+  const evaluated = {};
+  const reasons = [];
+
+  let chosen = null;
+  let chosenSource = 'empty';
+  let fallback = null;
+
+  for (const source of SOURCE_PRIORITY) {
+    const value = candidates[source];
+    const evaluation = evaluateCandidate(source, value);
+    if (!evaluation) {
+      continue;
+    }
+
+    evaluated[source] = evaluation;
+
+    if (!fallback || evaluation.metrics.length > fallback.metrics.length) {
+      fallback = evaluation;
+    }
+
+    if (!chosen && evaluation.metrics.isSubstantial) {
+      chosen = evaluation;
+      chosenSource = source;
+    }
+  }
+
+  if (!chosen && fallback) {
+    chosen = fallback;
+    chosenSource = fallback.source;
+    addReason(reasons, 'fallback-largest');
+  }
+
+  let bodyHtmlRaw = '';
+  let contentScore = 0;
+
+  if (chosen) {
+    bodyHtmlRaw = chosen.html;
+    contentScore = chosen.metrics.contentScore;
+
+    if (chosen.metrics.hasBlocks) {
+      addReason(reasons, 'has-block-tags');
+    }
+    if (chosen.metrics.length > 300) {
+      addReason(reasons, 'length>300');
+    }
+    if (chosen.metrics.paragraphCount >= 2) {
+      addReason(reasons, 'p-count>=2');
+    }
+    if (chosen.usedPlainTextWrapper) {
+      addReason(reasons, 'wrapped-plaintext');
+    }
+    if (chosen.removedBoilerplate) {
+      addReason(reasons, 'boilerplate-removed');
+    }
+  }
+
+  const bodyTruncation = truncateBodyHtml(bodyHtmlRaw);
+  if (bodyTruncation.truncated) {
+    bodyHtmlRaw = bodyTruncation.html;
+    addReason(reasons, 'truncated-150kb');
+  }
+
+  let leadHtmlRaw = null;
+  let leadUsed = false;
+  let dedupeRatio = 0;
+
+  const descriptionCandidate = evaluated.descriptionOrSummary;
+  if (descriptionCandidate && chosenSource !== 'descriptionOrSummary') {
+    let leadCandidateHtml = descriptionCandidate.html;
+
+    const normalizedBody = normalizeForComparison(bodyHtmlRaw);
+    const normalizedLead = normalizeForComparison(leadCandidateHtml);
+    dedupeRatio = computeDedupeRatio(normalizedBody, normalizedLead);
+
+    if (dedupeRatio >= 0.9) {
+      addReason(reasons, 'description-similar-omitted');
+    } else {
+      const truncatedLead = truncateHtmlByTextLength(leadCandidateHtml, LEAD_TEXT_LIMIT);
+      leadCandidateHtml = truncatedLead.html.trim();
+      if (truncatedLead.truncated) {
+        addReason(reasons, 'lead-truncated-400');
+      }
+
+      leadHtmlRaw = leadCandidateHtml;
+      leadUsed = true;
+    }
+  } else if (!descriptionCandidate) {
+    dedupeRatio = 0;
+  }
+
+  if (!leadUsed) {
+    leadHtmlRaw = null;
+  }
+
+  return {
+    bodyHtmlRaw,
+    leadHtmlRaw,
+    diagnostics: {
+      chosenSource,
+      contentScore,
+      leadUsed,
+      dedupeRatio,
+      reasons,
+    },
+  };
+};
+
+module.exports = {
+  selectBodyAndLead,
+};
+

--- a/backend/tests/fixtures/atom-text.xml
+++ b/backend/tests/fixtures/atom-text.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Text Only Atom Feed</title>
+  <entry>
+    <title>Status Update</title>
+    <id>tag:example.com,2025-02-11:/status-update</id>
+    <updated>2025-02-11T08:00:00Z</updated>
+    <content type="text">Status update without HTML tags</content>
+    <summary type="text">Short status summary</summary>
+  </entry>
+</feed>

--- a/backend/tests/fixtures/rss-minimal.xml
+++ b/backend/tests/fixtures/rss-minimal.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Minimal Feed</title>
+    <item>
+      <title>Quick Update</title>
+      <link>https://example.com/quick-update</link>
+      <pubDate>Fri, 07 Mar 2025 12:00:00 +0000</pubDate>
+      <description>Just a short note.</description>
+    </item>
+  </channel>
+</rss>

--- a/backend/tests/lib/body-lead-selector.test.js
+++ b/backend/tests/lib/body-lead-selector.test.js
@@ -1,0 +1,148 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { XMLParser } = require('fast-xml-parser');
+
+const { selectBodyAndLead } = require('../../src/lib/body-lead-selector');
+const { normalizeFeedItem } = require('../../src/lib/feed-normalizer');
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: '@_',
+  textNodeName: '#text',
+  trimValues: false,
+  parseTagValue: false,
+});
+
+const loadFixture = (name) =>
+  fs.readFileSync(path.join(__dirname, '..', 'fixtures', name), 'utf8');
+
+const getFirstItem = (parsed) => {
+  if (parsed.rss?.channel?.item) {
+    return Array.isArray(parsed.rss.channel.item)
+      ? parsed.rss.channel.item[0]
+      : parsed.rss.channel.item;
+  }
+  if (parsed.channel?.item) {
+    return Array.isArray(parsed.channel.item) ? parsed.channel.item[0] : parsed.channel.item;
+  }
+  if (parsed.feed?.entry) {
+    return Array.isArray(parsed.feed.entry) ? parsed.feed.entry[0] : parsed.feed.entry;
+  }
+  if (parsed.entry) {
+    return Array.isArray(parsed.entry) ? parsed.entry[0] : parsed.entry;
+  }
+  throw new Error('Unable to locate first feed item in fixture');
+};
+
+const normalizeFixture = (fixtureName) => {
+  const xml = loadFixture(fixtureName);
+  const parsed = parser.parse(xml);
+  const item = getFirstItem(parsed);
+  return normalizeFeedItem(item);
+};
+
+describe('selectBodyAndLead', () => {
+  it('selects content:encoded body and uses summary lead for Ghost/WordPress feeds', () => {
+    const normalized = normalizeFixture('rss-404media.xml');
+
+    const result = selectBodyAndLead(normalized);
+
+    expect(result.bodyHtmlRaw).toContain('The long-form story body.');
+    expect(result.leadHtmlRaw).toBe('<p>A short summary for the story.</p>');
+    expect(result.diagnostics.chosenSource).toBe('contentEncoded');
+    expect(result.diagnostics.contentScore).toBeGreaterThan(0.7);
+    expect(result.diagnostics.leadUsed).toBe(true);
+    expect(result.diagnostics.dedupeRatio).toBeLessThan(0.9);
+    expect(result.diagnostics.reasons).toContain('has-block-tags');
+  });
+
+  it('keeps Substack descriptions as lead when different from body', () => {
+    const normalized = normalizeFixture('rss-substack.xml');
+
+    const result = selectBodyAndLead(normalized);
+
+    expect(result.bodyHtmlRaw).toContain('<p>Hello readers!</p>');
+    expect(result.leadHtmlRaw).toBe('<p>Short intro &amp; highlights.</p>');
+    expect(result.diagnostics.chosenSource).toBe('contentEncoded');
+    expect(result.diagnostics.leadUsed).toBe(true);
+    expect(result.diagnostics.dedupeRatio).toBeLessThan(0.5);
+  });
+
+  it('prefers Atom content HTML and keeps summary as lead', () => {
+    const normalized = normalizeFixture('atom-example.xml');
+
+    const result = selectBodyAndLead(normalized);
+
+    expect(result.bodyHtmlRaw).toContain('Full article body');
+    expect(result.leadHtmlRaw).toBe('<p>Learn about orbits.</p>');
+    expect(result.diagnostics.chosenSource).toBe('content');
+    expect(result.diagnostics.leadUsed).toBe(true);
+  });
+
+  it('wraps plaintext Atom content in a paragraph and uses summary lead', () => {
+    const normalized = normalizeFixture('atom-text.xml');
+
+    const result = selectBodyAndLead(normalized);
+
+    expect(result.bodyHtmlRaw).toBe('<p>Status update without HTML tags</p>');
+    expect(result.leadHtmlRaw).toBe('<p>Short status summary</p>');
+    expect(result.diagnostics.chosenSource).toBe('content');
+    expect(result.diagnostics.reasons).toContain('wrapped-plaintext');
+  });
+
+  it('falls back to summary when no substantial body is available', () => {
+    const normalized = normalizeFixture('rss-minimal.xml');
+
+    const result = selectBodyAndLead(normalized);
+
+    expect(result.bodyHtmlRaw).toBe('<p>Just a short note.</p>');
+    expect(result.leadHtmlRaw).toBeNull();
+    expect(result.diagnostics.chosenSource).toBe('descriptionOrSummary');
+    expect(result.diagnostics.leadUsed).toBe(false);
+    expect(result.diagnostics.reasons).toContain('wrapped-plaintext');
+  });
+
+  it('deduplicates summary when identical to the body', () => {
+    const normalized = normalizeFixture('rss-wordpress.xml');
+
+    const result = selectBodyAndLead(normalized);
+
+    expect(result.bodyHtmlRaw).toContain('Launch day!');
+    expect(result.leadHtmlRaw).toBeNull();
+    expect(result.diagnostics.leadUsed).toBe(false);
+    expect(result.diagnostics.dedupeRatio).toBeGreaterThanOrEqual(0.9);
+    expect(result.diagnostics.reasons).toContain('description-similar-omitted');
+  });
+
+  it('truncates very large bodies and records diagnostics', () => {
+    const paragraph = `<p>${'A'.repeat(1024)}</p>`;
+    const hugeBody = paragraph.repeat(200);
+
+    const result = selectBodyAndLead({
+      rawHtmlCandidates: {
+        contentEncoded: hugeBody,
+      },
+    });
+
+    expect(result.bodyHtmlRaw.length).toBeLessThanOrEqual(150 * 1024);
+    expect(result.leadHtmlRaw).toBeNull();
+    expect(result.diagnostics.chosenSource).toBe('contentEncoded');
+    expect(result.diagnostics.reasons).toContain('truncated-150kb');
+  });
+
+  it('limits very long leads to 400 characters and appends ellipsis', () => {
+    const description = `<p>${'b'.repeat(450)}</p>`;
+
+    const result = selectBodyAndLead({
+      rawHtmlCandidates: {
+        contentEncoded: '<p>Body content stays full.</p>',
+        descriptionOrSummary: description,
+      },
+    });
+
+    expect(result.leadHtmlRaw).toMatch(/^<p>b{400}…<\/p>$/);
+    expect(result.diagnostics.leadUsed).toBe(true);
+    expect(result.diagnostics.reasons).toContain('lead-truncated-400');
+  });
+});


### PR DESCRIPTION
## Summary
- implement heuristics to pick the best raw body HTML and optional lead with scoring, dedupe, and truncation diagnostics
- cover Ghost, Substack, Atom, minimal RSS, duplicate summary, and oversized bodies with unit tests and new fixtures

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2d9abc5448325b505b2eaf62b5221