### PR TITLE
feat: assemble sanitized article html

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -24,6 +24,7 @@
                 "helmet": "^8.1.0",
                 "hpp": "^0.2.3",
                 "morgan": "^1.10.1",
+                "node-html-parser": "^6.1.13",
                 "pg": "^8.16.3",
                 "prisma": "^6.16.2",
                 "prom-client": "^15.1.3",
@@ -2366,6 +2367,12 @@
                 "npm": "1.2.8000 || >= 1.4.16"
             }
         },
+        "node_modules/boolbase": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+            "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+            "license": "ISC"
+        },
         "node_modules/brace-expansion": {
             "version": "1.1.12",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -2910,6 +2917,34 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/css-select": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+            "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "boolbase": "^1.0.0",
+                "css-what": "^6.1.0",
+                "domhandler": "^5.0.2",
+                "domutils": "^3.0.1",
+                "nth-check": "^2.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/css-what": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+            "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">= 6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
         "node_modules/debug": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -3021,6 +3056,61 @@
                 "node": ">=6.0.0"
             }
         },
+        "node_modules/dom-serializer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "entities": "^4.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+            }
+        },
+        "node_modules/domelementtype": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/domhandler": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "domelementtype": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/domutils": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+            "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "dom-serializer": "^2.0.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
         "node_modules/dotenv": {
             "version": "17.2.2",
             "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
@@ -3111,6 +3201,18 @@
             "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/error-ex": {
@@ -5554,6 +5656,16 @@
             "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
             "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="
         },
+        "node_modules/node-html-parser": {
+            "version": "6.1.13",
+            "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.13.tgz",
+            "integrity": "sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==",
+            "license": "MIT",
+            "dependencies": {
+                "css-select": "^5.1.0",
+                "he": "1.2.0"
+            }
+        },
         "node_modules/node-int64": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -5669,6 +5781,18 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/nth-check": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+            "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "boolbase": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/nth-check?sponsor=1"
             }
         },
         "node_modules/nypm": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -43,6 +43,7 @@
         "helmet": "^8.1.0",
         "hpp": "^0.2.3",
         "morgan": "^1.10.1",
+        "node-html-parser": "^6.1.13",
         "pg": "^8.16.3",
         "prisma": "^6.16.2",
         "prom-client": "^15.1.3",

--- a/backend/src/lib/article-assembler.js
+++ b/backend/src/lib/article-assembler.js
@@ -1,0 +1,912 @@
+const { parse, NodeType } = require('node-html-parser');
+const he = require('he');
+
+const DEFAULT_OPTIONS = {
+  keepEmbeds: false,
+  allowedIframeHosts: [],
+  injectTopImage: true,
+  excerptMaxChars: 220,
+  maxHtmlKB: 150,
+  stripKnownBoilerplates: true,
+};
+
+const ALLOWED_TAGS = new Set([
+  'p',
+  'h1',
+  'h2',
+  'h3',
+  'ul',
+  'ol',
+  'li',
+  'a',
+  'img',
+  'blockquote',
+  'strong',
+  'em',
+  'code',
+  'pre',
+  'figure',
+  'figcaption',
+  'hr',
+  'br',
+]);
+
+const VOID_TAGS = new Set(['img', 'hr', 'br']);
+
+const DROP_CONTENT_TAGS = new Set([
+  'script',
+  'style',
+  'object',
+  'embed',
+  'form',
+  'input',
+  'button',
+  'video',
+  'audio',
+]);
+
+const READ_MORE_PHRASES = new Set(['read more', 'continue reading']);
+
+const TRACKING_PARAM_NAMES = new Set([
+  'ref',
+  'fbclid',
+  'gclid',
+  'mc_eid',
+  'mc_cid',
+  'igshid',
+  'spm',
+  'xtor',
+  'mkt_tok',
+  'yclid',
+  'vero_id',
+]);
+
+const IMAGE_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.webp', '.gif']);
+
+const escapeHtml = (value) =>
+  String(value ?? '')
+    .replaceAll(/&/g, '&amp;')
+    .replaceAll(/</g, '&lt;')
+    .replaceAll(/>/g, '&gt;')
+    .replaceAll(/"/g, '&quot;')
+    .replaceAll(/'/g, '&#39;');
+
+const isHttpUrl = (value) => {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch (error) {
+    return false;
+  }
+};
+
+const normalizeAllowedHosts = (hosts) => {
+  if (!Array.isArray(hosts)) {
+    return [];
+  }
+  const normalized = [];
+  for (const host of hosts) {
+    if (typeof host !== 'string') {
+      continue;
+    }
+    const trimmed = host.trim().toLowerCase();
+    if (trimmed) {
+      normalized.push(trimmed);
+    }
+  }
+  return normalized;
+};
+
+const computeBaseUrls = (normalized) => {
+  const bases = [];
+  if (isHttpUrl(normalized?.canonicalUrl)) {
+    bases.push(normalized.canonicalUrl);
+  }
+  if (isHttpUrl(normalized?.sourceFeed?.url)) {
+    bases.push(normalized.sourceFeed.url);
+  }
+  return bases;
+};
+
+const sanitizeClassValue = (value) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const classes = value
+    .split(/\s+/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  return classes.length > 0 ? classes.join(' ') : null;
+};
+
+const addLeadClass = (leadHtmlRaw) => {
+  if (typeof leadHtmlRaw !== 'string') {
+    return '';
+  }
+  const trimmed = leadHtmlRaw.trim();
+  if (!trimmed) {
+    return '';
+  }
+  const paragraphMatch = trimmed.match(/^<p\b([^>]*)>([\s\S]*)<\/p>$/i);
+  if (paragraphMatch) {
+    const attrsRaw = paragraphMatch[1] ?? '';
+    const inner = paragraphMatch[2] ?? '';
+    const classMatch = attrsRaw.match(/\bclass\s*=\s*("([^"]*)"|'([^']*)'|([^\s"'>]+))/i);
+    let updatedAttrs = attrsRaw;
+    if (classMatch) {
+      const classValue = classMatch[2] ?? classMatch[3] ?? classMatch[4] ?? '';
+      const existingClasses = classValue
+        .split(/\s+/)
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+      if (!existingClasses.includes('lead')) {
+        existingClasses.push('lead');
+      }
+      const replacement = `class="${existingClasses.join(' ')}"`;
+      updatedAttrs = attrsRaw.replace(classMatch[0], ` ${replacement}`);
+    } else {
+      updatedAttrs = `${attrsRaw} class="lead"`;
+    }
+    const normalizedAttrs = updatedAttrs.replace(/\s+/g, ' ').trim();
+    const attrPart = normalizedAttrs ? ` ${normalizedAttrs}` : '';
+    return `<p${attrPart}>${inner}</p>`;
+  }
+  return `<p class="lead">${trimmed}</p>`;
+};
+
+const isLikelyImageUrl = (urlObject) => {
+  if (!urlObject || typeof urlObject !== 'object') {
+    return false;
+  }
+  if (!urlObject.pathname || urlObject.pathname.length <= 1) {
+    return false;
+  }
+  const lowerPath = urlObject.pathname.toLowerCase();
+  for (const extension of IMAGE_EXTENSIONS) {
+    if (lowerPath.endsWith(extension)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const normalizeUrlValue = (rawValue, context, { allowedSchemes, record = true } = {}) => {
+  if (typeof rawValue !== 'string') {
+    return { ok: false };
+  }
+  const trimmed = rawValue.trim();
+  if (!trimmed) {
+    return { ok: false };
+  }
+  const lower = trimmed.toLowerCase();
+  if (lower.startsWith('javascript:') || lower.startsWith('data:') || lower.startsWith('vbscript:')) {
+    return { ok: false };
+  }
+
+  if (lower.startsWith('mailto:')) {
+    if (!allowedSchemes.has('mailto')) {
+      return { ok: false };
+    }
+    if (record) {
+      context.diagnostics.linkFixes += 1;
+    }
+    return { ok: true, value: trimmed, protocol: 'mailto:' };
+  }
+
+  const candidates = [trimmed];
+  if (trimmed.startsWith('//')) {
+    candidates.unshift(`https:${trimmed}`);
+    candidates.push(`http:${trimmed}`);
+  }
+
+  let resolved = null;
+  const attemptWithBases = (value) => {
+    for (const base of [null, ...context.baseUrls]) {
+      try {
+        resolved = base ? new URL(value, base) : new URL(value);
+        if (resolved) {
+          return;
+        }
+      } catch (error) {
+        resolved = null;
+      }
+    }
+  };
+
+  for (const candidate of candidates) {
+    attemptWithBases(candidate);
+    if (resolved) {
+      break;
+    }
+  }
+
+  if (!resolved) {
+    attemptWithBases(trimmed);
+  }
+
+  if (!resolved) {
+    return { ok: false };
+  }
+
+  const protocol = resolved.protocol.toLowerCase();
+  const normalizedProtocol = protocol.endsWith(':') ? protocol.slice(0, -1) : protocol;
+  if (!allowedSchemes.has(normalizedProtocol)) {
+    return { ok: false };
+  }
+  if ((protocol === 'http:' || protocol === 'https:') && !resolved.hostname) {
+    return { ok: false };
+  }
+
+  let removedParams = 0;
+  if (protocol === 'http:' || protocol === 'https:') {
+    const params = resolved.searchParams;
+    for (const key of Array.from(params.keys())) {
+      const lowerKey = key.toLowerCase();
+      if (lowerKey.startsWith('utm_') || TRACKING_PARAM_NAMES.has(lowerKey)) {
+        const occurrences = params.getAll(key).length || 1;
+        removedParams += occurrences;
+        params.delete(key);
+      }
+    }
+  }
+
+  if (record) {
+    context.diagnostics.linkFixes += 1;
+    if (removedParams > 0) {
+      context.diagnostics.trackerParamsRemoved += removedParams;
+    }
+  }
+
+  const value = protocol === 'http:' || protocol === 'https:' ? resolved.toString() : trimmed;
+  return { ok: true, value, protocol, removedParams, urlObject: resolved };
+};
+
+const selectBestMediaResource = (resources, context) => {
+  if (!Array.isArray(resources) || resources.length === 0) {
+    return null;
+  }
+  let best = null;
+  for (const resource of resources) {
+    if (!resource || typeof resource !== 'object') {
+      continue;
+    }
+    const normalized = normalizeUrlValue(resource.url, context, {
+      allowedSchemes: new Set(['http', 'https']),
+      record: false,
+    });
+    if (!normalized.ok || !isLikelyImageUrl(normalized.urlObject)) {
+      continue;
+    }
+    const width = Number.isFinite(resource.width)
+      ? resource.width
+      : Number.parseInt(resource.width, 10);
+    const height = Number.isFinite(resource.height)
+      ? resource.height
+      : Number.parseInt(resource.height, 10);
+    const area = Number.isFinite(width) && Number.isFinite(height) ? width * height : 0;
+    if (!best || area > best.area) {
+      best = { normalizedUrl: normalized.value, area };
+    }
+  }
+  return best;
+};
+
+const selectMainImageCandidate = (normalized, context) => {
+  const media = normalized?.media;
+  if (!media || typeof media !== 'object') {
+    return null;
+  }
+
+  const mediaContent = selectBestMediaResource(media.mediaContent, context);
+  if (mediaContent) {
+    return { source: 'media:content', normalizedUrl: mediaContent.normalizedUrl };
+  }
+
+  const mediaThumbnail = selectBestMediaResource(media.mediaThumbnail, context);
+  if (mediaThumbnail) {
+    return { source: 'thumbnail', normalizedUrl: mediaThumbnail.normalizedUrl };
+  }
+
+  const enclosure = media.enclosureImage;
+  if (enclosure && typeof enclosure === 'object') {
+    const type = typeof enclosure.type === 'string' ? enclosure.type.toLowerCase() : '';
+    if (!type || type.startsWith('image/')) {
+      const normalized = normalizeUrlValue(enclosure.url, context, {
+        allowedSchemes: new Set(['http', 'https']),
+        record: false,
+      });
+      if (normalized.ok && isLikelyImageUrl(normalized.urlObject)) {
+        return { source: 'enclosure', normalizedUrl: normalized.value };
+      }
+    }
+  }
+
+  return null;
+};
+
+const createDiagnostics = () => ({
+  imageSource: 'none',
+  removedEmbeds: 0,
+  linkFixes: 0,
+  trackerParamsRemoved: 0,
+  truncated: false,
+  keptEmbedsHosts: [],
+});
+
+const createSanitizeContext = (baseUrls, diagnostics, options) => ({
+  baseUrls,
+  diagnostics,
+  options,
+  expectedTopImageUrl: null,
+  sanitizedTopImageUrl: null,
+  inlineImageCandidate: null,
+  keptEmbedsHosts: new Set(),
+});
+
+const createDescriptor = ({ type, tagName = null, html = '', textContent = '', attributes = null }) => ({
+  type,
+  tagName,
+  html,
+  textContent,
+  attributes,
+});
+
+const sanitizeChildren = (nodes, context) => {
+  const result = [];
+  for (const node of nodes) {
+    const sanitized = sanitizeNode(node, context);
+    if (sanitized.length > 0) {
+      result.push(...sanitized);
+    }
+  }
+  return result;
+};
+
+const sanitizeNode = (node, context) => {
+  if (!node) {
+    return [];
+  }
+  if (node.nodeType === NodeType.TEXT_NODE) {
+    const text = node.rawText ?? '';
+    if (!text) {
+      return [];
+    }
+    return [
+      createDescriptor({
+        type: 'text',
+        html: text,
+        textContent: node.text ?? text,
+      }),
+    ];
+  }
+  if (node.nodeType === NodeType.COMMENT_NODE) {
+    return [];
+  }
+  if (node.nodeType === NodeType.ELEMENT_NODE) {
+    return sanitizeElement(node, context);
+  }
+  return [];
+};
+
+const hasClass = (node, className) => {
+  const classAttr = node.getAttribute('class');
+  if (typeof classAttr !== 'string') {
+    return false;
+  }
+  return classAttr
+    .split(/\s+/)
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean)
+    .includes(className);
+};
+
+const sanitizeElement = (node, context) => {
+  const tagName = node.rawTagName ? node.rawTagName.toLowerCase() : '';
+  if (!tagName) {
+    return sanitizeChildren(node.childNodes, context);
+  }
+
+  if (context.options.stripKnownBoilerplates && hasClass(node, 'outpost-pub-container')) {
+    return [];
+  }
+
+  if (tagName === 'iframe') {
+    return sanitizeIframe(node, context);
+  }
+
+  if (DROP_CONTENT_TAGS.has(tagName)) {
+    return [];
+  }
+
+  if (!ALLOWED_TAGS.has(tagName)) {
+    return sanitizeChildren(node.childNodes, context);
+  }
+
+  if (tagName === 'a') {
+    return sanitizeAnchor(node, context);
+  }
+  if (tagName === 'img') {
+    return sanitizeImage(node, context);
+  }
+  if (tagName === 'br') {
+    return [createDescriptor({ type: 'element', tagName: 'br', html: '<br>', textContent: '' })];
+  }
+  if (tagName === 'hr') {
+    return [createDescriptor({ type: 'element', tagName: 'hr', html: '<hr>', textContent: '' })];
+  }
+
+  return sanitizeGenericElement(node, context, tagName);
+};
+
+const sanitizeAnchor = (node, context) => {
+  const hrefRaw = node.getAttribute('href');
+  const normalized = normalizeUrlValue(hrefRaw, context, {
+    allowedSchemes: new Set(['http', 'https', 'mailto']),
+  });
+  if (!normalized.ok) {
+    return sanitizeChildren(node.childNodes, context);
+  }
+
+  const children = sanitizeChildren(node.childNodes, context);
+  const textContent = children.map((child) => child.textContent).join('');
+  const attrs = [];
+  const attributesObject = {};
+  attrs.push(`href="${escapeHtml(normalized.value)}"`);
+  attributesObject.href = normalized.value;
+
+  const classValue = sanitizeClassValue(node.getAttribute('class'));
+  if (classValue) {
+    attrs.push(`class="${escapeHtml(classValue)}"`);
+    attributesObject.class = classValue;
+  }
+
+  const titleValue = node.getAttribute('title');
+  if (typeof titleValue === 'string' && titleValue.trim()) {
+    attrs.push(`title="${escapeHtml(titleValue.trim())}"`);
+    attributesObject.title = titleValue.trim();
+  }
+
+  if (normalized.protocol === 'http:' || normalized.protocol === 'https:') {
+    attrs.push('target="_blank"');
+    attrs.push('rel="noopener noreferrer"');
+    attributesObject.target = '_blank';
+    attributesObject.rel = 'noopener noreferrer';
+  }
+
+  const innerHtml = children.map((child) => child.html).join('');
+  const html = `<a ${attrs.join(' ')}>${innerHtml}</a>`;
+  return [
+    createDescriptor({
+      type: 'element',
+      tagName: 'a',
+      html,
+      textContent,
+      attributes: attributesObject,
+    }),
+  ];
+};
+
+const sanitizeImage = (node, context) => {
+  const srcRaw = node.getAttribute('src');
+  const normalized = normalizeUrlValue(srcRaw, context, {
+    allowedSchemes: new Set(['http', 'https']),
+  });
+  if (!normalized.ok || !isLikelyImageUrl(normalized.urlObject)) {
+    return [];
+  }
+
+  const attrs = [];
+  const attributesObject = {};
+  attrs.push(`src="${escapeHtml(normalized.value)}"`);
+  attributesObject.src = normalized.value;
+
+  const classValue = sanitizeClassValue(node.getAttribute('class'));
+  if (classValue) {
+    attrs.push(`class="${escapeHtml(classValue)}"`);
+    attributesObject.class = classValue;
+  }
+
+  const altAttr = node.getAttribute('alt');
+  if (typeof altAttr === 'string') {
+    attrs.push(`alt="${escapeHtml(altAttr)}"`);
+    attributesObject.alt = altAttr;
+  } else {
+    attrs.push('alt=""');
+    attributesObject.alt = '';
+  }
+
+  const titleAttr = node.getAttribute('title');
+  if (typeof titleAttr === 'string' && titleAttr.trim()) {
+    attrs.push(`title="${escapeHtml(titleAttr.trim())}"`);
+    attributesObject.title = titleAttr.trim();
+  }
+
+  const widthAttr = node.getAttribute('width');
+  if (typeof widthAttr === 'string') {
+    const normalizedWidth = Number.parseInt(widthAttr, 10);
+    if (Number.isFinite(normalizedWidth) && normalizedWidth > 0) {
+      attrs.push(`width="${normalizedWidth}"`);
+      attributesObject.width = String(normalizedWidth);
+    }
+  }
+
+  const heightAttr = node.getAttribute('height');
+  if (typeof heightAttr === 'string') {
+    const normalizedHeight = Number.parseInt(heightAttr, 10);
+    if (Number.isFinite(normalizedHeight) && normalizedHeight > 0) {
+      attrs.push(`height="${normalizedHeight}"`);
+      attributesObject.height = String(normalizedHeight);
+    }
+  }
+
+  attrs.push('loading="lazy"');
+  attrs.push('decoding="async"');
+  attributesObject.loading = 'lazy';
+  attributesObject.decoding = 'async';
+
+  const html = `<img ${attrs.join(' ')}>`;
+
+  if (context.expectedTopImageUrl && normalized.value === context.expectedTopImageUrl) {
+    context.sanitizedTopImageUrl = normalized.value;
+  }
+  if (!context.inlineImageCandidate && normalized.value !== context.expectedTopImageUrl) {
+    context.inlineImageCandidate = normalized.value;
+  }
+
+  return [
+    createDescriptor({ type: 'element', tagName: 'img', html, textContent: '', attributes: attributesObject }),
+  ];
+};
+
+const sanitizeGenericElement = (node, context, tagName) => {
+  const children = sanitizeChildren(node.childNodes, context);
+  const innerHtml = children.map((child) => child.html).join('');
+  const textContent = children.map((child) => child.textContent).join('');
+
+  const attrs = [];
+  const attributesObject = {};
+  const classValue = sanitizeClassValue(node.getAttribute('class'));
+  if (classValue) {
+    attrs.push(`class="${escapeHtml(classValue)}"`);
+    attributesObject.class = classValue;
+  }
+
+  const attrString = attrs.length > 0 ? ` ${attrs.join(' ')}` : '';
+  const closing = VOID_TAGS.has(tagName) ? '' : `</${tagName}>`;
+  const html = `<${tagName}${attrString}>${innerHtml}${closing}`;
+
+  return [
+    createDescriptor({
+      type: 'element',
+      tagName,
+      html,
+      textContent,
+      attributes: attributesObject,
+    }),
+  ];
+};
+
+const sanitizeIframe = (node, context) => {
+  const { options, diagnostics } = context;
+  if (!options.keepEmbeds) {
+    diagnostics.removedEmbeds += 1;
+    return [];
+  }
+  const srcRaw = node.getAttribute('src');
+  const normalized = normalizeUrlValue(srcRaw, context, {
+    allowedSchemes: new Set(['https']),
+  });
+  if (!normalized.ok) {
+    diagnostics.removedEmbeds += 1;
+    return [];
+  }
+
+  const host = normalized.urlObject.hostname.toLowerCase();
+  if (!options.allowedIframeHosts.includes(host)) {
+    diagnostics.removedEmbeds += 1;
+    return [];
+  }
+
+  context.keptEmbedsHosts.add(host);
+
+  const attrs = [`src="${escapeHtml(normalized.value)}"`, 'loading="lazy"', 'allowfullscreen'];
+  const attributesObject = { src: normalized.value, loading: 'lazy', allowfullscreen: '' };
+
+  const classValue = sanitizeClassValue(node.getAttribute('class'));
+  if (classValue) {
+    attrs.push(`class="${escapeHtml(classValue)}"`);
+    attributesObject.class = classValue;
+  }
+
+  const titleAttr = node.getAttribute('title');
+  if (typeof titleAttr === 'string' && titleAttr.trim()) {
+    attrs.push(`title="${escapeHtml(titleAttr.trim())}"`);
+    attributesObject.title = titleAttr.trim();
+  }
+
+  const widthAttr = node.getAttribute('width');
+  if (typeof widthAttr === 'string') {
+    const normalizedWidth = Number.parseInt(widthAttr, 10);
+    if (Number.isFinite(normalizedWidth) && normalizedWidth > 0) {
+      attrs.push(`width="${normalizedWidth}"`);
+      attributesObject.width = String(normalizedWidth);
+    }
+  }
+
+  const heightAttr = node.getAttribute('height');
+  if (typeof heightAttr === 'string') {
+    const normalizedHeight = Number.parseInt(heightAttr, 10);
+    if (Number.isFinite(normalizedHeight) && normalizedHeight > 0) {
+      attrs.push(`height="${normalizedHeight}"`);
+      attributesObject.height = String(normalizedHeight);
+    }
+  }
+
+  const html = `<iframe ${attrs.join(' ')}></iframe>`;
+  return [
+    createDescriptor({
+      type: 'element',
+      tagName: 'iframe',
+      html,
+      textContent: '',
+      attributes: attributesObject,
+    }),
+  ];
+};
+
+const stripTrailingWhitespace = (nodes) => {
+  while (nodes.length > 0) {
+    const last = nodes[nodes.length - 1];
+    if (last.type === 'text' && !last.textContent.trim()) {
+      nodes.pop();
+      continue;
+    }
+    break;
+  }
+};
+
+const isIsolatedReadMoreParagraph = (node) => {
+  if (node.type !== 'element' || node.tagName !== 'p') {
+    return false;
+  }
+  const rawText = node.textContent.replace(/\s+/g, ' ').trim().toLowerCase();
+  const normalized = rawText.replace(/[.!?…›»→-]+$/g, '').trim();
+  return READ_MORE_PHRASES.has(normalized);
+};
+
+const stripBoilerplateParagraphs = (nodes) => {
+  for (let index = nodes.length - 1; index >= 0; index -= 1) {
+    if (isIsolatedReadMoreParagraph(nodes[index])) {
+      nodes.splice(index, 1);
+    }
+  }
+  stripTrailingWhitespace(nodes);
+};
+
+const sanitizeFragment = (html, context) => {
+  if (!html) {
+    return { html: '', nodes: [] };
+  }
+  const root = parse(html, { comment: true });
+  const nodes = sanitizeChildren(root.childNodes, context);
+  if (context.options.stripKnownBoilerplates) {
+    stripBoilerplateParagraphs(nodes);
+  }
+  const serialized = nodes.map((node) => node.html).join('\n').trim();
+  return { html: serialized, nodes };
+};
+
+const truncateHtmlIfNeeded = (html, maxHtmlKB, diagnostics) => {
+  if (!html) {
+    return { html, truncated: false };
+  }
+  const limitKb = Number.isFinite(maxHtmlKB) && maxHtmlKB > 0 ? maxHtmlKB : DEFAULT_OPTIONS.maxHtmlKB;
+  const limitBytes = Math.floor(limitKb * 1024);
+  const htmlBuffer = Buffer.from(html, 'utf8');
+  if (htmlBuffer.length <= limitBytes) {
+    return { html, truncated: false };
+  }
+
+  const truncatedBuffer = htmlBuffer.subarray(0, limitBytes);
+  let truncatedHtml = truncatedBuffer.toString('utf8');
+  const closingTags = ['</p>', '</figure>', '</ul>', '</ol>', '</pre>', '</code>', '</blockquote>', '</h1>', '</h2>', '</h3>', '</li>'];
+  let cutIndex = -1;
+  for (const closing of closingTags) {
+    const index = truncatedHtml.lastIndexOf(closing);
+    if (index > cutIndex) {
+      cutIndex = index + closing.length;
+    }
+  }
+  if (cutIndex > -1) {
+    truncatedHtml = truncatedHtml.slice(0, cutIndex);
+  }
+  truncatedHtml = truncatedHtml.trimEnd();
+  const notice = '<p><em>Conteúdo truncado.</em></p>';
+  diagnostics.truncated = true;
+  return { html: `${truncatedHtml}${truncatedHtml ? '\n' : ''}${notice}`, truncated: true };
+};
+
+const generateExcerptText = (nodes, maxChars) => {
+  if (!nodes || nodes.length === 0) {
+    return '';
+  }
+  const parts = [];
+  for (const node of nodes) {
+    if (node.type === 'element') {
+      if (node.tagName === 'figure') {
+        continue;
+      }
+      const classValue = node.attributes?.class ?? '';
+      const hasMetaClass = classValue
+        .split(/\s+/)
+        .map((entry) => entry.trim())
+        .filter(Boolean)
+        .some((entry) => entry.startsWith('article-meta'));
+      if (hasMetaClass) {
+        continue;
+      }
+    }
+    const text = node.textContent;
+    if (typeof text === 'string' && text.trim()) {
+      parts.push(text);
+    }
+  }
+  if (parts.length === 0) {
+    return '';
+  }
+  const combined = parts.join(' ');
+  const normalized = he
+    .decode(combined)
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!normalized) {
+    return '';
+  }
+  const limit = Number.isFinite(maxChars) && maxChars > 0 ? maxChars : DEFAULT_OPTIONS.excerptMaxChars;
+  if (normalized.length <= limit) {
+    return normalized;
+  }
+  let truncated = normalized.slice(0, limit);
+  const lastSpace = truncated.lastIndexOf(' ');
+  if (lastSpace > Math.floor(limit * 0.6)) {
+    truncated = truncated.slice(0, lastSpace);
+  }
+  return `${truncated.trimEnd()}…`;
+};
+
+const buildMetaHtml = (normalized) => {
+  const metaParts = [];
+  if (normalized?.author) {
+    metaParts.push(
+      `<p class="article-meta article-meta-author"><strong>Autor:</strong> ${escapeHtml(normalized.author)}</p>`,
+    );
+  }
+  if (normalized?.publishedAtISO) {
+    metaParts.push(
+      `<p class="article-meta article-meta-date"><strong>Publicado:</strong> ${escapeHtml(normalized.publishedAtISO)}</p>`,
+    );
+  }
+  if (normalized?.canonicalUrl) {
+    metaParts.push(
+      `<p class="article-meta article-meta-source"><strong>Fonte:</strong> <a href="${escapeHtml(
+        normalized.canonicalUrl,
+      )}">${escapeHtml(normalized.canonicalUrl)}</a></p>`,
+    );
+  }
+  if (Array.isArray(normalized?.categories) && normalized.categories.length > 0) {
+    metaParts.push(
+      `<p class="article-meta article-meta-tags"><strong>Tags:</strong> ${escapeHtml(
+        normalized.categories.join(', '),
+      )}</p>`,
+    );
+  }
+  return metaParts.join('\n');
+};
+
+const buildBaseHtml = (normalized, contentChoice, imageCandidate, options) => {
+  const segments = [];
+  const leadHtml = addLeadClass(contentChoice.leadHtmlRaw);
+  if (leadHtml) {
+    segments.push(leadHtml);
+  }
+  if (options.injectTopImage && imageCandidate?.normalizedUrl) {
+    segments.push(`<figure><img src="${imageCandidate.normalizedUrl}" alt=""></figure>`);
+  }
+  if (typeof contentChoice.bodyHtmlRaw === 'string' && contentChoice.bodyHtmlRaw.trim()) {
+    segments.push(contentChoice.bodyHtmlRaw);
+  }
+  const metaHtml = buildMetaHtml(normalized);
+  if (metaHtml) {
+    segments.push(metaHtml);
+  }
+  return segments.join('\n');
+};
+
+/**
+ * Builds sanitized article HTML, selects a main image candidate and generates
+ * a text excerpt suitable for feed cards.
+ *
+ * @param {object} normalized - Normalized feed item produced by the feed normalizer.
+ * @param {{ bodyHtmlRaw: string, leadHtmlRaw?: string | null }} contentChoice -
+ *   Result from the body/lead selector containing the chosen raw HTML fragments.
+ * @param {object} [options]
+ * @param {boolean} [options.keepEmbeds=false] - Keep safe iframe embeds for whitelisted hosts.
+ * @param {string[]} [options.allowedIframeHosts=[]] - Hosts allowed when keepEmbeds is enabled.
+ * @param {boolean} [options.injectTopImage=true] - Inject main image at the top of the article.
+ * @param {number} [options.excerptMaxChars=220] - Maximum number of characters for the excerpt.
+ * @param {number} [options.maxHtmlKB=150] - Maximum HTML size in kilobytes before truncation.
+ * @param {boolean} [options.stripKnownBoilerplates=true] - Remove known boilerplate blocks.
+ * @returns {{
+ *   articleHtml: string,
+ *   mainImageUrl: string | undefined,
+ *   excerpt: string,
+ *   diagnostics: {
+ *     imageSource: string,
+ *     removedEmbeds: number,
+ *     linkFixes: number,
+ *     trackerParamsRemoved: number,
+ *     truncated: boolean,
+ *     keptEmbedsHosts: string[],
+ *   },
+ * }}
+ */
+const assembleArticle = (normalized, contentChoice, options = {}) => {
+  if (!normalized || typeof normalized !== 'object') {
+    throw new TypeError('normalized must be an object');
+  }
+  if (!contentChoice || typeof contentChoice !== 'object') {
+    throw new TypeError('contentChoice must be an object');
+  }
+
+  const mergedOptions = {
+    ...DEFAULT_OPTIONS,
+    ...options,
+  };
+  mergedOptions.allowedIframeHosts = normalizeAllowedHosts(mergedOptions.allowedIframeHosts);
+
+  const diagnostics = createDiagnostics();
+  const baseUrls = computeBaseUrls(normalized);
+  const sanitizeContext = createSanitizeContext(baseUrls, diagnostics, mergedOptions);
+
+  const imageCandidate = selectMainImageCandidate(normalized, sanitizeContext);
+  if (imageCandidate?.normalizedUrl) {
+    diagnostics.imageSource = imageCandidate.source;
+    if (mergedOptions.injectTopImage) {
+      sanitizeContext.expectedTopImageUrl = imageCandidate.normalizedUrl;
+    }
+  }
+
+  const baseHtml = buildBaseHtml(normalized, contentChoice, imageCandidate, mergedOptions);
+  const sanitized = sanitizeFragment(baseHtml, sanitizeContext);
+  let articleHtml = sanitized.html;
+
+  const truncation = truncateHtmlIfNeeded(articleHtml, mergedOptions.maxHtmlKB, diagnostics);
+  articleHtml = truncation.html;
+
+  const excerpt = generateExcerptText(sanitized.nodes, mergedOptions.excerptMaxChars);
+
+  let mainImageUrl = imageCandidate?.normalizedUrl;
+  if (!mainImageUrl && sanitizeContext.inlineImageCandidate) {
+    mainImageUrl = sanitizeContext.inlineImageCandidate;
+    diagnostics.imageSource = 'inline';
+  }
+  if (!mainImageUrl) {
+    diagnostics.imageSource = 'none';
+  }
+
+  diagnostics.keptEmbedsHosts = Array.from(sanitizeContext.keptEmbedsHosts);
+
+  return {
+    articleHtml,
+    mainImageUrl: mainImageUrl ?? undefined,
+    excerpt,
+    diagnostics,
+  };
+};
+
+module.exports = {
+  assembleArticle,
+};

--- a/backend/tests/lib/article-assembler.test.js
+++ b/backend/tests/lib/article-assembler.test.js
@@ -1,0 +1,181 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { XMLParser } = require('fast-xml-parser');
+
+const { normalizeFeedItem } = require('../../src/lib/feed-normalizer');
+const { selectBodyAndLead } = require('../../src/lib/body-lead-selector');
+const { assembleArticle } = require('../../src/lib/article-assembler');
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: '@_',
+  textNodeName: '#text',
+  trimValues: false,
+  parseTagValue: false,
+});
+
+const loadFixture = (name) =>
+  fs.readFileSync(path.join(__dirname, '..', 'fixtures', name), 'utf8');
+
+const parseFirstItem = (xml) => {
+  const parsed = parser.parse(xml);
+  if (parsed.rss?.channel?.item) {
+    return Array.isArray(parsed.rss.channel.item)
+      ? parsed.rss.channel.item[0]
+      : parsed.rss.channel.item;
+  }
+  if (parsed.feed?.entry) {
+    return Array.isArray(parsed.feed.entry) ? parsed.feed.entry[0] : parsed.feed.entry;
+  }
+  throw new Error('Unable to locate item in fixture');
+};
+
+describe('assembleArticle', () => {
+  it('builds sanitized html with media hero metadata', () => {
+    const xml = loadFixture('rss-404media.xml');
+    const item = parseFirstItem(xml);
+    const normalized = normalizeFeedItem(item, { feedUrl: 'https://www.404media.co/rss/' });
+    const bodySelection = selectBodyAndLead(normalized);
+
+    const result = assembleArticle(normalized, bodySelection);
+
+    expect(result.articleHtml).toContain('<p class="lead">A short summary for the story.</p>');
+    expect(result.articleHtml).toContain(
+      '<figure><img src="https://static.404media.co/images/story-main.jpg"',
+    );
+    expect(result.articleHtml).toContain('loading="lazy"');
+    expect(result.articleHtml).toContain('decoding="async"');
+    expect(result.articleHtml).toContain(
+      '<a href="https://www.404media.co/inside-the-example-conspiracy/" target="_blank" rel="noopener noreferrer">',
+    );
+
+    expect(result.mainImageUrl).toBe('https://static.404media.co/images/story-main.jpg');
+    expect(result.excerpt).toBe('A short summary for the story. The long-form story body.');
+    expect(result.diagnostics.imageSource).toBe('media:content');
+    expect(result.diagnostics.removedEmbeds).toBe(0);
+    expect(result.diagnostics.trackerParamsRemoved).toBe(0);
+  });
+
+  it('removes iframe embeds by default', () => {
+    const normalized = {
+      canonicalUrl: 'https://example.com/post',
+      rawHtmlCandidates: {},
+    };
+    const choice = {
+      bodyHtmlRaw:
+        '<p>Audio episode</p><iframe src="https://playlist.megaphone.fm/episode?utm_source=rss"></iframe>',
+      leadHtmlRaw: null,
+    };
+
+    const result = assembleArticle(normalized, choice);
+
+    expect(result.articleHtml).not.toContain('<iframe');
+    expect(result.diagnostics.removedEmbeds).toBe(1);
+    expect(result.diagnostics.keptEmbedsHosts).toEqual([]);
+  });
+
+  it('keeps whitelisted iframe embeds when enabled', () => {
+    const normalized = {
+      canonicalUrl: 'https://example.com/post',
+      rawHtmlCandidates: {},
+    };
+    const choice = {
+      bodyHtmlRaw:
+        '<p>Audio episode</p><iframe src="https://playlist.megaphone.fm/episode?utm_source=rss"></iframe>',
+      leadHtmlRaw: null,
+    };
+
+    const result = assembleArticle(normalized, choice, {
+      keepEmbeds: true,
+      allowedIframeHosts: ['playlist.megaphone.fm'],
+    });
+
+    expect(result.articleHtml).toContain(
+      '<iframe src="https://playlist.megaphone.fm/episode" loading="lazy" allowfullscreen',
+    );
+    expect(result.diagnostics.removedEmbeds).toBe(0);
+    expect(result.diagnostics.keptEmbedsHosts).toEqual(['playlist.megaphone.fm']);
+    expect(result.diagnostics.trackerParamsRemoved).toBe(1);
+  });
+
+  it('normalizes inline links and images when no media metadata exists', () => {
+    const normalized = {
+      canonicalUrl: 'https://example.com/post?utm_source=rss',
+      sourceFeed: { url: 'https://example.com/feed?utm_medium=rss' },
+      categories: ['Updates'],
+      rawHtmlCandidates: {},
+    };
+    const choice = {
+      leadHtmlRaw: 'Lead text',
+      bodyHtmlRaw:
+        '<p>Intro paragraph with a <a href="/relative?utm_campaign=news&ref=link" style="color:red" onclick="alert(1)">Go</a>.</p>' +
+        '<p><img src="/images/photo.png?utm_medium=rss" alt="Photo"></p>' +
+        '<div class="outpost-pub-container"><p>Promoted</p></div>' +
+        '<p>Read more</p>',
+    };
+
+    const result = assembleArticle(normalized, choice, { injectTopImage: false });
+
+    expect(result.articleHtml).toContain(
+      '<a href="https://example.com/relative" target="_blank" rel="noopener noreferrer">Go</a>',
+    );
+    expect(result.articleHtml).toContain('<p class="lead">Lead text</p>');
+    expect(result.articleHtml).toContain('<img src="https://example.com/images/photo.png"');
+    expect(result.articleHtml).not.toContain('outpost-pub-container');
+    expect(result.articleHtml).not.toMatch(/Read more/i);
+    expect(result.articleHtml).not.toContain('onclick');
+    expect(result.articleHtml).not.toContain('style=');
+
+    expect(result.mainImageUrl).toBe('https://example.com/images/photo.png');
+    expect(result.diagnostics.imageSource).toBe('inline');
+    expect(result.diagnostics.trackerParamsRemoved).toBe(4);
+    expect(result.diagnostics.linkFixes).toBe(3);
+    expect(result.excerpt).toBe('Lead text Intro paragraph with a Go.');
+  });
+
+  it('prefers enclosure image when available', () => {
+    const xml = loadFixture('rss-substack.xml');
+    const item = parseFirstItem(xml);
+    const normalized = normalizeFeedItem(item);
+    const bodySelection = selectBodyAndLead(normalized);
+
+    const result = assembleArticle(normalized, bodySelection);
+
+    expect(result.mainImageUrl).toBe('https://substackcdn.com/image.jpg');
+    expect(result.articleHtml).toContain('<figure><img src="https://substackcdn.com/image.jpg"');
+    expect(result.diagnostics.imageSource).toBe('enclosure');
+  });
+
+  it('truncates very large html payloads and marks diagnostics', () => {
+    const normalized = {
+      canonicalUrl: 'https://example.com/big',
+      rawHtmlCandidates: {},
+    };
+    const choice = {
+      leadHtmlRaw: null,
+      bodyHtmlRaw: '<p>' + 'Long text '.repeat(5000) + '</p>',
+    };
+
+    const result = assembleArticle(normalized, choice, { maxHtmlKB: 1 });
+
+    expect(result.diagnostics.truncated).toBe(true);
+    expect(result.articleHtml).toContain('<p><em>Conteúdo truncado.</em></p>');
+  });
+
+  it('respects excerpt length configuration', () => {
+    const normalized = {
+      canonicalUrl: 'https://example.com/custom',
+      rawHtmlCandidates: {},
+    };
+    const choice = {
+      leadHtmlRaw: 'Lead text for excerpt sizing',
+      bodyHtmlRaw: '<p>' + 'Body content '.repeat(40) + '</p>',
+    };
+
+    const result = assembleArticle(normalized, choice, { excerptMaxChars: 80 });
+
+    expect(result.excerpt.length).toBeLessThanOrEqual(81);
+    expect(result.excerpt.endsWith('…')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- implement an article assembler that sanitizes feed HTML, normalizes links, chooses a hero image, and builds diagnostics
- add unit tests covering media selection, embed handling, truncation, and excerpt generation
- include node-html-parser dependency for HTML parsing in the sanitizer

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2df538f348325baf63208234ae02b