### PR TITLE
Add admin RSS feed reset endpoint and UI

### DIFF
--- a/backend/src/controllers/feed.controller.js
+++ b/backend/src/controllers/feed.controller.js
@@ -91,10 +91,19 @@ const remove = asyncHandler(async (req, res) => {
   return res.success({ message: 'Feed removed' });
 });
 
+const reset = asyncHandler(async (req, res) => {
+  const adminId = req.user?.id != null ? String(req.user.id) : null;
+
+  const result = await feedService.resetAllFeeds({ requestedBy: adminId });
+
+  return res.success(result);
+});
+
 module.exports = {
   list,
   create,
   bulkCreate,
   update,
   remove,
+  reset,
 };

--- a/backend/src/docs/openapi.js
+++ b/backend/src/docs/openapi.js
@@ -144,6 +144,15 @@ const definition = {
           message: { type: 'string', example: 'Feed removed' },
         },
       },
+      FeedResetResult: {
+        type: 'object',
+        properties: {
+          feedsResetCount: { type: 'integer', example: 12 },
+          articlesDeletedCount: { type: 'integer', example: 480 },
+          postsDeletedCount: { type: 'integer', example: 480 },
+          durationMs: { type: 'integer', example: 85 },
+        },
+      },
       FeedRefreshSummary: {
         type: 'object',
         properties: {

--- a/frontend/src/features/feeds/api/feeds.ts
+++ b/frontend/src/features/feeds/api/feeds.ts
@@ -7,6 +7,8 @@ import {
   type FeedBulkResult,
   type FeedList,
   type FeedListMeta,
+  feedResetSummarySchema,
+  type FeedResetSummary,
 } from '../types/feed';
 
 import { deleteJson, getJsonWithMeta, patchJson, postJson } from '@/lib/api/http';
@@ -67,4 +69,12 @@ export const updateFeed = (id: number, payload: { url?: string; title?: string |
 
 export const deleteFeed = (id: number) => {
   return deleteJson<{ message: string }>(`/api/v1/feeds/${id}`);
+};
+
+export const resetAllFeeds = () => {
+  return postJson<FeedResetSummary, Record<string, never>>(
+    '/api/v1/feeds/reset',
+    {},
+    feedResetSummarySchema,
+  );
 };

--- a/frontend/src/features/feeds/types/feed.ts
+++ b/frontend/src/features/feeds/types/feed.ts
@@ -55,3 +55,12 @@ export const feedBulkResultSchema = z.object({
 });
 
 export type FeedBulkResult = z.infer<typeof feedBulkResultSchema>;
+
+export const feedResetSummarySchema = z.object({
+  feedsResetCount: z.number().int().nonnegative(),
+  articlesDeletedCount: z.number().int().nonnegative(),
+  postsDeletedCount: z.number().int().nonnegative(),
+  durationMs: z.number().int().nonnegative(),
+});
+
+export type FeedResetSummary = z.infer<typeof feedResetSummarySchema>;


### PR DESCRIPTION
## Summary
- add an admin-only RSS feed reset endpoint with transactional cleanup and logging
- document the reset response schema and counts in the OpenAPI spec and tests
- surface an admin-only reset button in the feeds UI backed by a new hook and Vitest coverage

## Testing
- npm test (backend)
- npm test (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68d302b71e088325b7d06b7c9a4f76d5