### PR TITLE
feat: add ingestion diagnostics and expose sanitized article HTML

### DIFF
--- a/backend/src/controllers/diagnostics.controller.js
+++ b/backend/src/controllers/diagnostics.controller.js
@@ -1,0 +1,48 @@
+const asyncHandler = require('../utils/async-handler');
+const ingestionDiagnostics = require('../services/ingestion-diagnostics');
+
+const toIsoString = (value) => {
+  if (value instanceof Date) {
+    const timestamp = value.valueOf();
+    if (!Number.isNaN(timestamp)) {
+      return new Date(timestamp).toISOString();
+    }
+    return null;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.valueOf()) ? null : parsed.toISOString();
+  }
+
+  return null;
+};
+
+const listIngestionDiagnostics = asyncHandler(async (req, res) => {
+  const { limit, feedId } = req.validated?.query ?? {};
+  const entries = ingestionDiagnostics.getRecent({ limit, feedId });
+
+  const items = entries.map((entry) => ({
+    itemId: entry.articleId,
+    feedId: entry.feedId ?? null,
+    feedTitle: entry.feedTitle ?? null,
+    itemTitle: entry.itemTitle ?? null,
+    canonicalUrl: entry.canonicalUrl ?? null,
+    publishedAt: toIsoString(entry.publishedAt),
+    chosenSource: entry.chosenSource,
+    rawDescriptionLength: entry.rawDescriptionLength,
+    bodyHtmlRawLength: entry.bodyHtmlRawLength,
+    articleHtmlLength: entry.articleHtmlLength,
+    hasBlockTags: entry.hasBlockTags,
+    looksEscapedHtml: entry.looksEscapedHtml,
+    weakContent: entry.weakContent,
+    articleHtmlPreview: entry.articleHtmlPreview,
+    recordedAt: toIsoString(entry.recordedAt),
+  }));
+
+  return res.success({ items });
+});
+
+module.exports = {
+  listIngestionDiagnostics,
+};

--- a/backend/src/routes/v1/diagnostics.routes.js
+++ b/backend/src/routes/v1/diagnostics.routes.js
@@ -1,0 +1,11 @@
+const express = require('express');
+
+const diagnosticsController = require('../../controllers/diagnostics.controller');
+const { validateRequest } = require('../../middlewares/validate-request');
+const { ingestionDiagnosticsQuerySchema } = require('../../schemas/diagnostics.schema');
+
+const router = express.Router();
+
+router.get('/ingestion', validateRequest({ query: ingestionDiagnosticsQuerySchema }), diagnosticsController.listIngestionDiagnostics);
+
+module.exports = router;

--- a/backend/src/routes/v1/index.js
+++ b/backend/src/routes/v1/index.js
@@ -4,6 +4,7 @@ const helloRoutes = require('./hello.routes');
 const feedRoutes = require('./feed.routes');
 const postsRoutes = require('./posts.routes');
 const allowlistRoutes = require('./allowlist.routes');
+const diagnosticsRoutes = require('./diagnostics.routes');
 const { requireAuth } = require('../../middlewares/authentication');
 const { requireRole, ROLES } = require('../../middlewares/authorization');
 
@@ -15,5 +16,6 @@ router.use(helloRoutes);
 router.use(feedRoutes);
 router.use(postsRoutes);
 router.use('/allowlist', requireRole(ROLES.ADMIN), allowlistRoutes);
+router.use('/diagnostics', requireRole(ROLES.ADMIN), diagnosticsRoutes);
 
 module.exports = router;

--- a/backend/src/schemas/diagnostics.schema.js
+++ b/backend/src/schemas/diagnostics.schema.js
@@ -1,0 +1,24 @@
+const { z } = require('zod');
+
+const ingestionDiagnosticsQuerySchema = z.object({
+  limit: z
+    .preprocess((value) => {
+      if (value == null || value === '') {
+        return undefined;
+      }
+      const parsed = Number(value);
+      return Number.isFinite(parsed) ? parsed : undefined;
+    }, z.number().int().min(1).max(200).optional()),
+  feedId: z
+    .preprocess((value) => {
+      if (value == null || value === '') {
+        return undefined;
+      }
+      const parsed = Number(value);
+      return Number.isFinite(parsed) ? parsed : undefined;
+    }, z.number().int().positive().optional()),
+});
+
+module.exports = {
+  ingestionDiagnosticsQuerySchema,
+};

--- a/backend/src/services/ingestion-diagnostics.js
+++ b/backend/src/services/ingestion-diagnostics.js
@@ -1,0 +1,90 @@
+const MAX_ENTRIES = 200;
+
+const diagnosticsMap = new Map();
+
+const normalizeInteger = (value) => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.trunc(value));
+};
+
+const normalizeString = (value) => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value;
+};
+
+const record = (entry) => {
+  if (!entry || entry.articleId == null) {
+    return;
+  }
+
+  const normalized = {
+    articleId: entry.articleId,
+    feedId: entry.feedId ?? null,
+    feedTitle: entry.feedTitle ?? null,
+    itemTitle: entry.itemTitle ?? null,
+    canonicalUrl: entry.canonicalUrl ?? null,
+    publishedAt: entry.publishedAt ? new Date(entry.publishedAt) : null,
+    chosenSource: entry.chosenSource ?? 'empty',
+    rawDescriptionLength: normalizeInteger(entry.rawDescriptionLength),
+    bodyHtmlRawLength: normalizeInteger(entry.bodyHtmlRawLength),
+    articleHtmlLength: normalizeInteger(entry.articleHtmlLength),
+    hasBlockTags: Boolean(entry.hasBlockTags),
+    looksEscapedHtml: Boolean(entry.looksEscapedHtml),
+    weakContent: Boolean(entry.weakContent),
+    articleHtmlPreview: normalizeString(entry.articleHtmlPreview),
+    recordedAt: entry.recordedAt ? new Date(entry.recordedAt) : new Date(),
+  };
+
+  if (diagnosticsMap.has(normalized.articleId)) {
+    diagnosticsMap.delete(normalized.articleId);
+  }
+
+  diagnosticsMap.set(normalized.articleId, normalized);
+
+  while (diagnosticsMap.size > MAX_ENTRIES) {
+    const oldestKey = diagnosticsMap.keys().next().value;
+    diagnosticsMap.delete(oldestKey);
+  }
+};
+
+const getRecent = ({ limit, feedId } = {}) => {
+  const safeLimit = (() => {
+    if (limit == null) {
+      return 25;
+    }
+    const numeric = Number(limit);
+    if (!Number.isFinite(numeric)) {
+      return 25;
+    }
+    return Math.max(1, Math.min(MAX_ENTRIES, Math.trunc(numeric)));
+  })();
+
+  const allEntries = Array.from(diagnosticsMap.values()).reverse();
+  const items = [];
+
+  for (const entry of allEntries) {
+    if (feedId != null && entry.feedId !== feedId) {
+      continue;
+    }
+    items.push(entry);
+    if (items.length >= safeLimit) {
+      break;
+    }
+  }
+
+  return items;
+};
+
+const reset = () => {
+  diagnosticsMap.clear();
+};
+
+module.exports = {
+  record,
+  getRecent,
+  reset,
+};

--- a/backend/src/services/rss-metrics.js
+++ b/backend/src/services/rss-metrics.js
@@ -55,6 +55,16 @@ const trackerParamsRemoved = new client.Counter({
   help: 'Total number of tracker parameters removed from links.',
 });
 
+const articleHtmlWithBlockTags = new client.Counter({
+  name: 'article_html_with_blocktags_total',
+  help: 'Number of ingested articles whose final HTML contains block-level tags.',
+});
+
+const articleHtmlEscaped = new client.Counter({
+  name: 'article_html_escaped_total',
+  help: 'Number of ingested articles whose final HTML looks HTML-escaped.',
+});
+
 const itemDurationMs = new client.Histogram({
   name: 'rss_item_duration_ms',
   help: 'Processing duration per RSS item in milliseconds.',
@@ -112,6 +122,18 @@ const addTrackerParamsRemoved = (count) => {
   }
 };
 
+const recordArticleHtmlBlockTags = (hasBlockTags) => {
+  if (hasBlockTags) {
+    articleHtmlWithBlockTags.inc();
+  }
+};
+
+const recordArticleHtmlEscaped = (looksEscaped) => {
+  if (looksEscaped) {
+    articleHtmlEscaped.inc();
+  }
+};
+
 const observeItemDuration = (durationMs) => {
   if (typeof durationMs === 'number' && Number.isFinite(durationMs) && durationMs >= 0) {
     itemDurationMs.observe(durationMs);
@@ -129,6 +151,8 @@ const resetMetrics = () => {
   truncatedHtml.reset();
   removedEmbedsCount.reset();
   trackerParamsRemoved.reset();
+  articleHtmlWithBlockTags.reset();
+  articleHtmlEscaped.reset();
   itemDurationMs.reset();
 };
 
@@ -143,6 +167,8 @@ module.exports = {
   recordTruncated,
   addRemovedEmbeds,
   addTrackerParamsRemoved,
+  recordArticleHtmlBlockTags,
+  recordArticleHtmlEscaped,
   observeItemDuration,
   resetMetrics,
 };

--- a/backend/src/utils/html-diagnostics.js
+++ b/backend/src/utils/html-diagnostics.js
@@ -1,0 +1,39 @@
+const BLOCK_TAG_REGEX = /<(p|div|img|h1|h2|h3|ul|ol|li|figure|pre|code|blockquote)\b/i;
+const ESCAPED_BLOCK_TAG_REGEX = /&(lt|#60);\/?(p|div|img|h1|h2|h3|ul|ol|li|figure|pre|code|blockquote)/i;
+
+const ensureString = (value) => (typeof value === 'string' ? value : '');
+
+const hasBlockTags = (html) => BLOCK_TAG_REGEX.test(ensureString(html));
+
+const looksEscapedHtml = (html) => ESCAPED_BLOCK_TAG_REGEX.test(ensureString(html));
+
+const collapseWhitespace = (value) => value.replace(/\s+/g, ' ').trim();
+
+const computeWeakContent = ({ html }) => {
+  const content = ensureString(html);
+  const normalized = collapseWhitespace(content);
+  const length = normalized.length;
+  const containsBlocks = hasBlockTags(content);
+  return {
+    length,
+    containsBlocks,
+    weak: length < 300 || !containsBlocks,
+  };
+};
+
+const buildPreview = (html, maxLength = 300) => {
+  if (typeof html !== 'string' || maxLength <= 0) {
+    return '';
+  }
+  if (html.length <= maxLength) {
+    return html;
+  }
+  return html.slice(0, maxLength);
+};
+
+module.exports = {
+  hasBlockTags,
+  looksEscapedHtml,
+  computeWeakContent,
+  buildPreview,
+};

--- a/backend/tests/posts.service.test.js
+++ b/backend/tests/posts.service.test.js
@@ -9,6 +9,7 @@ const {
 const { prisma } = require('../src/lib/prisma');
 const rssMetrics = require('../src/services/rss-metrics');
 const config = require('../src/config');
+const ingestionDiagnostics = require('../src/services/ingestion-diagnostics');
 
 const toRssDate = (date) => new Date(date).toUTCString();
 
@@ -103,6 +104,7 @@ describe('posts.service', () => {
   beforeEach(() => {
     prisma.__reset();
     rssMetrics.resetMetrics();
+    ingestionDiagnostics.reset();
     Object.assign(config.rss, {
       keepEmbeds: false,
       allowedIframeHosts: [],


### PR DESCRIPTION
## Summary
- add in-memory ingestion diagnostics tracking plus an admin-only `/diagnostics/ingestion` endpoint with filtering and preview data
- ensure RSS ingestion persists the assembled HTML, records diagnostics/metrics, and posts API returns the stored HTML with preview flags for admins
- extend backend tests with fixtures to validate full HTML persistence, diagnostics exposure, and minimal-feed weak content handling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3246ed13c8325b791f07ebd35563b