### PR TITLE
Render full article HTML on Posts page

### DIFF
--- a/frontend/src/config/i18n.ts
+++ b/frontend/src/config/i18n.ts
@@ -217,6 +217,12 @@ const resources = {
             article: 'NEWS',
           },
           postUnavailable: 'Post not available yet.',
+          article: {
+            readMore: 'See more',
+            readLess: 'See less',
+            partialAdminNotice: 'This article looks partial. Review the feed extraction.',
+            unavailable: 'News content not available yet.',
+          },
           empty: {
             default: {
               title: 'No recent posts.',
@@ -509,6 +515,12 @@ const resources = {
             article: 'NOTICIA',
           },
           postUnavailable: 'Post ainda nao disponivel.',
+          article: {
+            readMore: 'Ver mais',
+            readLess: 'Ver menos',
+            partialAdminNotice: 'Conteudo parcial da noticia. Verifique a coleta no feed.',
+            unavailable: 'Noticia indisponivel no momento.',
+          },
           empty: {
             default: {
               title: 'Nenhum post recente.',

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -38,6 +38,101 @@
   .card {
     @apply rounded-lg border border-border bg-surface shadow-sm;
   }
+
+  .article-content {
+    @apply space-y-4 text-sm leading-relaxed text-foreground;
+  }
+
+  .article-content p {
+    @apply leading-7;
+    margin: 0;
+  }
+
+  .article-content h1 {
+    @apply text-2xl font-semibold leading-snug text-foreground;
+    margin-top: 1.75rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .article-content h2 {
+    @apply text-xl font-semibold leading-snug text-foreground;
+    margin-top: 1.5rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .article-content h3 {
+    @apply text-lg font-semibold leading-snug text-foreground;
+    margin-top: 1.25rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .article-content ul,
+  .article-content ol {
+    @apply my-4 ml-6 space-y-2;
+  }
+
+  .article-content ul {
+    list-style-type: disc;
+  }
+
+  .article-content ol {
+    list-style-type: decimal;
+  }
+
+  .article-content li {
+    @apply leading-7;
+  }
+
+  .article-content blockquote {
+    @apply my-4 border-l-4 border-primary/40 pl-4 italic text-muted-foreground;
+  }
+
+  .article-content pre {
+    @apply my-4 overflow-x-auto rounded-md bg-muted/40 p-4 text-sm font-mono;
+  }
+
+  .article-content code {
+    @apply rounded bg-muted/40 px-1 py-0.5 text-sm;
+  }
+
+  .article-content figure {
+    @apply my-4;
+  }
+
+  .article-content figcaption {
+    @apply mt-2 text-xs text-muted-foreground;
+  }
+
+  .article-content img,
+  .article-content video,
+  .article-content iframe {
+    @apply my-4 rounded-md;
+    max-width: 100%;
+    height: auto;
+  }
+
+  .article-content a {
+    @apply font-medium text-primary underline underline-offset-4 transition-colors duration-200 hover:text-primary/80;
+  }
+
+  .article-content--collapsed {
+    @apply relative overflow-hidden;
+  }
+
+  .article-content--collapsed::after {
+    content: '';
+    position: absolute;
+    inset-inline: 0;
+    bottom: 0;
+    height: 4rem;
+    background: linear-gradient(
+      to top,
+      hsl(var(--color-background)) 0%,
+      hsl(var(--color-background) / 0.8) 60%,
+      hsl(var(--color-background) / 0) 100%
+    );
+    pointer-events: none;
+  }
 }
 
 @layer utilities {


### PR DESCRIPTION
## Summary
- render sanitized news HTML via the memoized `ArticleContent` component with collapse controls, responsive media, and admin fallback messaging
- add supporting typography styles for injected article markup and expose new translations for the article controls
- extend the Posts page tests to cover HTML rendering, collapse/expand toggling, weak-content fallbacks, and external link handling

## Testing
- npm run test -- PostsPage
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d32b23cff48325af046cc1e68411fc