### PR TITLE
Refine feed refresh handling and simplify article content

### DIFF
--- a/frontend/src/pages/feeds/FeedsPage.tsx
+++ b/frontend/src/pages/feeds/FeedsPage.tsx
@@ -153,7 +153,9 @@ const FeedsPage = () => {
     }
 
     setShouldRefreshFeeds(false);
-    void refetchFeedList();
+    Promise.resolve(refetchFeedList()).catch(() => {
+      // the query state already exposes fetch errors to the UI
+    });
   }, [shouldRefreshFeeds, refetchFeedList]);
 
   const resolveErrorMessage = (error: unknown): string => {


### PR DESCRIPTION
## Summary
- wrap feed refetch operations in a settled promise to avoid unhandled rejections when no promise is returned
- refactor `ArticleContent` helpers to lower complexity, ensure DOM enhancements are applied via dedicated utilities, and expose article metadata for debugging
- replace legacy string helpers with `replaceAll` and collapse rendering conditionals for better readability

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d3df2fe4d48325b4494e2aeab7b1ce