### PR TITLE
Address SonarCloud lint issues

### DIFF
--- a/backend/tests/rss.ingestion.e2e.test.js
+++ b/backend/tests/rss.ingestion.e2e.test.js
@@ -111,7 +111,7 @@ describe('RSS ingestion end-to-end', () => {
       allowedIframeHosts: ['open.spotify.com'],
       trackerParamsRemoveList: ['custom'],
     });
-    const feed = await createFeed({ url: 'https://newsletter.example.com/rss' });
+    await createFeed({ url: 'https://newsletter.example.com/rss' });
     const fetcher = buildFetchMock(loadFixture('rss-substack.xml'));
 
     const result = await refreshUserFeeds({ ownerKey: '1', now: new Date('2025-02-05T09:00:00Z'), fetcher });
@@ -123,7 +123,7 @@ describe('RSS ingestion end-to-end', () => {
   });
 
   it('renders Atom HTML entries and preserves inline images', async () => {
-    const feed = await createFeed({ url: 'https://example.com/atom.xml' });
+    await createFeed({ url: 'https://example.com/atom.xml' });
     const fetcher = buildFetchMock(loadFixture('atom-example.xml'));
 
     await refreshUserFeeds({ ownerKey: '1', now: new Date('2025-02-11T08:00:00Z'), fetcher });
@@ -134,7 +134,7 @@ describe('RSS ingestion end-to-end', () => {
   });
 
   it('wraps Atom text entries in paragraphs', async () => {
-    const feed = await createFeed({ url: 'https://example.com/status.xml' });
+    await createFeed({ url: 'https://example.com/status.xml' });
     const fetcher = buildFetchMock(loadFixture('atom-text.xml'));
 
     await refreshUserFeeds({ ownerKey: '1', now: new Date('2025-02-11T09:00:00Z'), fetcher });
@@ -161,7 +161,7 @@ describe('RSS ingestion end-to-end', () => {
   });
 
   it('truncates overly long content and appends a truncation notice', async () => {
-    const feed = await createFeed({ url: 'https://example.com/huge.xml' });
+    await createFeed({ url: 'https://example.com/huge.xml' });
     const fetcher = buildFetchMock(loadFixture('rss-large.xml'));
 
     await refreshUserFeeds({ ownerKey: '1', now: new Date('2025-02-06T12:00:00Z'), fetcher });
@@ -174,7 +174,7 @@ describe('RSS ingestion end-to-end', () => {
 
   it('skips overwriting articles when reprocess policy is set to never', async () => {
     config.rss.reprocessPolicy = 'never';
-    const feed = await createFeed({ url: 'https://example.com/policy.xml' });
+    await createFeed({ url: 'https://example.com/policy.xml' });
     const fixtureA = loadFixture('rss-minimal.xml');
     const fixtureB = fixtureA.replace('Just a short entry.', 'Updated entry content.');
     const fetcher = jest
@@ -199,7 +199,7 @@ describe('RSS ingestion end-to-end', () => {
 
   it('updates stored HTML when content changes under if-empty-or-changed policy', async () => {
     config.rss.reprocessPolicy = 'if-empty-or-changed';
-    const feed = await createFeed({ url: 'https://example.com/update.xml' });
+    await createFeed({ url: 'https://example.com/update.xml' });
     const fixtureA = loadFixture('rss-minimal.xml');
     const fixtureB = fixtureA.replace('Just a short entry.', 'A brand new entry body.');
     const fetcher = jest

--- a/frontend/src/features/posts/utils/extractArticlePreview.ts
+++ b/frontend/src/features/posts/utils/extractArticlePreview.ts
@@ -78,26 +78,29 @@ const parseHtml = (html: string): ParsedRoot | null => {
 const removeFooterElements = (root: HTMLElement) => {
   const selectors = FOOTER_CLASS_KEYWORDS.map((keyword) => `[class*="${keyword}"]`).join(',');
   if (selectors) {
-    root.querySelectorAll(selectors).forEach((element) => {
+    const elements = root.querySelectorAll(selectors);
+    for (const element of elements) {
       if (element instanceof HTMLElement) {
         element.remove();
       }
-    });
+    }
   }
 
-  root.querySelectorAll('footer').forEach((element) => {
+  const footers = root.querySelectorAll('footer');
+  for (const element of footers) {
     element.remove();
-  });
+  }
 };
 
 const sanitizeRoot = (root: HTMLElement) => {
-  root.querySelectorAll('script, style, noscript').forEach((element) => {
+  const removable = root.querySelectorAll('script, style, noscript');
+  for (const element of removable) {
     element.remove();
-  });
+  }
   removeFooterElements(root);
 };
 
-const normalizeWhitespace = (value: string) => value.replace(/\s+/g, ' ').trim();
+const normalizeWhitespace = (value: string) => value.replaceAll(/\s+/g, ' ').trim();
 
 const findTruncationPoint = (text: string, preferred: number, fallback: number) => {
   const clamp = (limit: number) => {

--- a/frontend/src/pages/news/NewsDetailPage.tsx
+++ b/frontend/src/pages/news/NewsDetailPage.tsx
@@ -106,10 +106,10 @@ const NewsDetailPage = () => {
     }
 
     const anchors = container.querySelectorAll('a');
-    anchors.forEach((anchor) => {
+    for (const anchor of anchors) {
       anchor.setAttribute('target', '_blank');
       anchor.setAttribute('rel', 'noopener noreferrer');
-    });
+    }
   }, [cachedPost?.html]);
 
   if (!postId) {
@@ -125,7 +125,7 @@ const NewsDetailPage = () => {
     );
   }
 
-  if (!cachedPost || !cachedPost.html) {
+  if (!cachedPost?.html) {
     return (
       <section className="space-y-4">
         <p className="text-lg font-semibold text-foreground">
@@ -138,7 +138,8 @@ const NewsDetailPage = () => {
     );
   }
 
-  const publishedDate = formatDate(cachedPost.publishedAt);
+  const post = cachedPost;
+  const publishedDate = formatDate(post.publishedAt);
 
   return (
     <section className="space-y-6">
@@ -151,17 +152,17 @@ const NewsDetailPage = () => {
       </button>
 
       <header className="space-y-2">
-        <h1 className="text-3xl font-display font-semibold leading-tight text-foreground">{cachedPost.title}</h1>
-        {(publishedDate || cachedPost.author) && (
+        <h1 className="text-3xl font-display font-semibold leading-tight text-foreground">{post.title}</h1>
+        {(publishedDate || post.author) && (
           <p className="text-sm text-muted-foreground">
             {publishedDate ? t('news.detail.publishedAt', 'Publicado em {{date}}', { date: publishedDate }) : null}
-            {publishedDate && cachedPost.author ? ' • ' : null}
-            {cachedPost.author ?? ''}
+            {publishedDate && post.author ? ' • ' : null}
+            {post.author ?? ''}
           </p>
         )}
-        {cachedPost.link ? (
+        {post.link ? (
           <a
-            href={cachedPost.link}
+            href={post.link}
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center text-sm font-medium text-primary hover:underline"
@@ -174,7 +175,7 @@ const NewsDetailPage = () => {
       <div
         ref={articleRef}
         className="space-y-4 text-base leading-relaxed text-foreground [&_a]:text-primary [&_a]:underline [&_figure]:my-6 [&_img]:h-auto [&_img]:max-w-full [&_img]:rounded-lg [&_p]:my-4"
-        dangerouslySetInnerHTML={{ __html: cachedPost.html }}
+        dangerouslySetInnerHTML={{ __html: post.html }}
       />
     </section>
   );


### PR DESCRIPTION
## Summary
- apply optional chaining and replace forEach usage in the news detail page to lower cognitive noise flagged by SonarCloud
- iterate DOM node lists with for…of loops and switch to `replaceAll` in the article preview helper to comply with preferred patterns
- drop unused `feed` variables in RSS ingestion tests that were triggering useless-assignment warnings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3ed9cc24c832585153e08767ad439