### PR TITLE
Improve article assembler diagnostics and cleanup

### DIFF
--- a/backend/src/services/posts.service.js
+++ b/backend/src/services/posts.service.js
@@ -591,6 +591,12 @@ const fetchAndParseFeed = async (url, fetcher, timeoutMs) => {
         truncated: false,
         removedEmbeds: 0,
         trackerParamsRemoved: 0,
+        linkFixes: 0,
+        keptEmbedsHosts: [],
+        urlParseErrors: 0,
+        lastUrlParseError: null,
+        htmlParseErrorCount: 0,
+        lastHtmlParseError: null,
       };
       let articleHtml = '';
       let usedFallback = false;
@@ -638,6 +644,12 @@ const fetchAndParseFeed = async (url, fetcher, timeoutMs) => {
           truncated: false,
           removedEmbeds: 0,
           trackerParamsRemoved: 0,
+          linkFixes: 0,
+          keptEmbedsHosts: [],
+          urlParseErrors: 0,
+          lastUrlParseError: null,
+          htmlParseErrorCount: 0,
+          lastHtmlParseError: null,
         };
       }
 


### PR DESCRIPTION
## Summary
- avoid throwing URL parsing helpers and prefer String#replaceAll where appropriate
- record URL/HTML parse failures in article assembler diagnostics and reuse them downstream
- align fallback diagnostics defaults in post service with the expanded diagnostics payload

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d40b434cd0832590287d723c0c7c7a