### PR TITLE
Fix Sonar code smells

### DIFF
--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -91,7 +91,7 @@ const envSchema = z.object({
     .default('if-empty-or-changed'),
   RSS_LOG_LEVEL: z
     .preprocess((value) => (typeof value === 'string' ? value.trim().toLowerCase() : value ?? 'info'), z.string())
-    .transform((value) => (value ? value : 'info')),
+    .transform((value) => value || 'info'),
   RSS_TRACKER_PARAMS_REMOVE_LIST: z
     .preprocess((value) => {
       const list = toList(value, []);

--- a/backend/src/controllers/feed.controller.js
+++ b/backend/src/controllers/feed.controller.js
@@ -38,7 +38,7 @@ const list = asyncHandler(async (req, res) => {
     },
     {
       meta: {
-        nextCursor: nextCursor != null ? String(nextCursor) : null,
+        nextCursor: nextCursor == null ? null : String(nextCursor),
         total,
         limit: appliedLimit,
       },
@@ -92,7 +92,7 @@ const remove = asyncHandler(async (req, res) => {
 });
 
 const reset = asyncHandler(async (req, res) => {
-  const adminId = req.user?.id != null ? String(req.user.id) : null;
+  const adminId = req.user?.id == null ? null : String(req.user.id);
 
   const result = await feedService.resetAllFeeds({ requestedBy: adminId });
 

--- a/backend/src/lib/article-assembler.js
+++ b/backend/src/lib/article-assembler.js
@@ -65,11 +65,11 @@ const IMAGE_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.webp', '.gif']);
 
 const escapeHtml = (value) =>
   String(value ?? '')
-    .replaceAll(/&/g, '&amp;')
-    .replaceAll(/</g, '&lt;')
-    .replaceAll(/>/g, '&gt;')
-    .replaceAll(/"/g, '&quot;')
-    .replaceAll(/'/g, '&#39;');
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
 
 const isHttpUrl = (value) => {
   if (typeof value !== 'string') {

--- a/backend/src/lib/body-lead-selector.js
+++ b/backend/src/lib/body-lead-selector.js
@@ -41,12 +41,12 @@ const wrapPlainText = (value) => {
 const removeTrivialBoilerplate = (html) => {
   let result = html;
 
-  result = result.replace(
+  result = result.replaceAll(
     /<div[^>]*class="[^"]*\boutpost-pub-container\b[^"]*"[^>]*>[\s\S]*?<\/div>/gi,
     '',
   );
 
-  result = result.replace(
+  result = result.replaceAll(
     /(?:\s*<p[^>]*>\s*(?:<a[^>]*>\s*)?(?:read more|continue reading)[^<]*?(?:<\/a>)?\s*<\/p>\s*)+$/gim,
     '',
   );
@@ -189,7 +189,7 @@ const truncateHtmlByTextLength = (html, limit) => {
     return { html, truncated: false };
   }
 
-  result = result.replace(/\s+$/, '');
+  result = result.replaceAll(/\s+$/g, '');
   result += '…';
 
   for (let i = stack.length - 1; i >= 0; i -= 1) {
@@ -233,9 +233,9 @@ const normalizeForComparison = (html) => {
   if (!html) {
     return '';
   }
-  const withoutTags = html.replace(/<[^>]*>/g, ' ');
+  const withoutTags = html.replaceAll(/<[^>]*>/g, ' ');
   const decoded = he.decode(withoutTags, { isAttributeValue: false });
-  return decoded.replace(/\s+/g, ' ').trim().toLowerCase();
+  return decoded.replaceAll(/\s+/g, ' ').trim().toLowerCase();
 };
 
 const computeDedupeRatio = (a, b) => {

--- a/backend/src/services/posts.service.js
+++ b/backend/src/services/posts.service.js
@@ -179,11 +179,11 @@ const sanitizeIdentifier = (value) => {
 
 const escapeHtml = (value) =>
   String(value ?? '')
-    .replaceAll(/&/g, '&amp;')
-    .replaceAll(/</g, '&lt;')
-    .replaceAll(/>/g, '&gt;')
-    .replaceAll(/"/g, '&quot;')
-    .replaceAll(/'/g, '&#39;');
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
 
 const buildFallbackArticleHtml = ({ title, link }) => {
   const safeTitle = escapeHtml(title ?? '');
@@ -235,14 +235,14 @@ const isHtmlEmpty = (value) => {
   if (typeof value !== 'string') {
     return true;
   }
-  return value.replace(/\s+/g, '').length === 0;
+  return value.replaceAll(/\s+/g, '').length === 0;
 };
 
 const normalizeHtmlForDiff = (value) => {
   if (typeof value !== 'string') {
     return '';
   }
-  return value.replace(/\s+/g, ' ').trim();
+  return value.replaceAll(/\s+/g, ' ').trim();
 };
 
 const hasSubstantialHtmlChange = (currentHtml, newHtml) => {

--- a/backend/src/utils/html-diagnostics.js
+++ b/backend/src/utils/html-diagnostics.js
@@ -7,7 +7,7 @@ const hasBlockTags = (html) => BLOCK_TAG_REGEX.test(ensureString(html));
 
 const looksEscapedHtml = (html) => ESCAPED_BLOCK_TAG_REGEX.test(ensureString(html));
 
-const collapseWhitespace = (value) => value.replace(/\s+/g, ' ').trim();
+const collapseWhitespace = (value) => value.replaceAll(/\s+/g, ' ').trim();
 
 const computeWeakContent = ({ html }) => {
   const content = ensureString(html);

--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -124,7 +124,7 @@ jest.mock('../src/lib/prisma', () => {
     }
 
     if (typeof expected === 'object' && expected !== null) {
-      if (Object.prototype.hasOwnProperty.call(expected, 'not')) {
+      if (Object.hasOwn(expected, 'not')) {
         const negated = expected.not;
         return !matchNullableDateField(actual, negated);
       }
@@ -499,7 +499,7 @@ jest.mock('../src/lib/prisma', () => {
           feeds[index] = {
             ...feeds[index],
             ...data,
-            updatedAt: Object.prototype.hasOwnProperty.call(data, 'updatedAt') ? data.updatedAt : now,
+            updatedAt: Object.hasOwn(data, 'updatedAt') ? data.updatedAt : now,
           };
         }
 
@@ -749,7 +749,7 @@ jest.mock('../src/lib/prisma', () => {
           throw new Error('Record not found');
         }
 
-        if (Object.prototype.hasOwnProperty.call(data, 'articleHtml')) {
+        if (Object.hasOwn(data, 'articleHtml')) {
           article.articleHtml = data.articleHtml ?? null;
         }
 


### PR DESCRIPTION
## Summary
- replace string replacements in HTML utilities to use `replaceAll` and direct literals where appropriate
- update feed controller null checks and env default transform to address negated conditions
- switch test helpers to `Object.hasOwn` and keep HTML normalization consistent

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d40e7690808325939a0da360eea065