### PR TITLE
Refine posts page sync flow and simplify body lead parsing

### DIFF
--- a/backend/src/services/posts.service.js
+++ b/backend/src/services/posts.service.js
@@ -12,7 +12,7 @@ const { createLogger } = require('./rss-logger');
 const rssMetrics = require('./rss-metrics');
 const config = require('../config');
 const ingestionDiagnostics = require('./ingestion-diagnostics');
-const { hasBlockTags, looksEscapedHtml, computeWeakContent, buildPreview } = require('../utils/html-diagnostics');
+const { looksEscapedHtml, computeWeakContent, buildPreview } = require('../utils/html-diagnostics');
 
 const COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
 const WINDOW_DAYS = 7;


### PR DESCRIPTION
## Summary
- extract helper hooks on the Posts page to manage title updates, initial sync, and summary reset while keeping admin awareness
- replace the complex trailing "read more" regular expression with iterative paragraph stripping and tidy truncation control flow
- remove an unused HTML diagnostic import to keep lint clean

## Testing
- npm run lint --prefix backend
- npm run lint --prefix frontend
- npm run test --prefix backend

------
https://chatgpt.com/codex/tasks/task_e_68d41742122c832586119fd99094e132