### PR TITLE
Reduce complexity in feed normalization and posts page

### DIFF
--- a/backend/src/lib/body-lead-selector.js
+++ b/backend/src/lib/body-lead-selector.js
@@ -50,7 +50,7 @@ const stripTrailingReadMoreParagraphs = (html) => {
 
   while (match) {
     const paragraph = match[0];
-    const normalizedText = paragraph.replace(TAG_OR_ENTITY_REGEX, ' ').toLowerCase();
+    const normalizedText = paragraph.replaceAll(TAG_OR_ENTITY_REGEX, ' ').toLowerCase();
 
     if (!containsReadMoreKeyword(normalizedText)) {
       break;


### PR DESCRIPTION
## Summary
- refactor feed text extraction and category helpers to reduce cognitive complexity
- replace String#replace usage with replaceAll in the body lead selector
- extract refresh summary aggregation logic so PostsPage stays under the complexity limit

## Testing
- npm run lint (backend)
- npm run lint (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68d41a5037508325826906d2bd3953e6