### PR TITLE
feat(backend): add global app params management

### DIFF
--- a/backend/docs/openapi.json
+++ b/backend/docs/openapi.json
@@ -4,7 +4,7 @@
     "title": "lkdposts API",
     "version": "1.0.0",
     "description": "API responsável por disponibilizar funcionalidades de automação de posts.",
-    "x-generated-at": "2025-09-22T00:36:05.136Z",
+    "x-generated-at": "2025-09-25T16:37:38.453Z",
     "x-environment": "development"
   },
   "servers": [
@@ -154,6 +154,179 @@
           }
         }
       },
+      "AppParams": {
+        "type": "object",
+        "properties": {
+          "posts_refresh_cooldown_seconds": {
+            "type": "integer",
+            "minimum": 0,
+            "example": 3600
+          },
+          "posts_time_window_days": {
+            "type": "integer",
+            "minimum": 1,
+            "example": 7
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2025-01-20T12:34:56.000Z"
+          },
+          "updated_by": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "admin@example.com"
+          }
+        }
+      },
+      "AllowlistListResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AllowedUser"
+            }
+          }
+        }
+      },
+      "AllowlistCreateRequest": {
+        "type": "object",
+        "required": [
+          "email",
+          "role"
+        ],
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "example": "user@example.com"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "admin",
+              "user"
+            ],
+            "example": "user"
+          }
+        }
+      },
+      "AllowlistUpdateRoleRequest": {
+        "type": "object",
+        "required": [
+          "role"
+        ],
+        "properties": {
+          "role": {
+            "type": "string",
+            "enum": [
+              "admin",
+              "user"
+            ],
+            "example": "admin"
+          }
+        }
+      },
+      "AllowlistRemovalResult": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "example": "Allowlist entry removed"
+          }
+        }
+      },
+      "AuthGoogleLoginRequest": {
+        "type": "object",
+        "required": [
+          "idToken"
+        ],
+        "properties": {
+          "idToken": {
+            "type": "string",
+            "description": "Google ID token obtained from the client SDK.",
+            "example": "ya29.a0AfH6SMCg..."
+          }
+        }
+      },
+      "AuthSession": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "example": "user@example.com"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "admin",
+              "user"
+            ],
+            "example": "user"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2025-01-20T13:45:00.000Z"
+          }
+        }
+      },
+      "AuthLogoutResult": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "example": "Logged out"
+          }
+        }
+      },
+      "AuthDebugReport": {
+        "type": "object",
+        "properties": {
+          "origin": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "https://app.example.com"
+          },
+          "hasCookie": {
+            "type": "boolean",
+            "example": true
+          },
+          "cookieNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "lkdposts_session"
+            ]
+          },
+          "authenticated": {
+            "type": "boolean",
+            "example": true
+          },
+          "userIdOrEmail": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "user@example.com"
+          },
+          "release": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "2025.01.20-abcdef"
+          }
+        }
+      },
       "FeedDuplicateEntry": {
         "type": "object",
         "properties": {
@@ -223,6 +396,27 @@
           "message": {
             "type": "string",
             "example": "Feed removed"
+          }
+        }
+      },
+      "FeedResetResult": {
+        "type": "object",
+        "properties": {
+          "feedsResetCount": {
+            "type": "integer",
+            "example": 12
+          },
+          "articlesDeletedCount": {
+            "type": "integer",
+            "example": 480
+          },
+          "postsDeletedCount": {
+            "type": "integer",
+            "example": 480
+          },
+          "durationMs": {
+            "type": "integer",
+            "example": 85
           }
         }
       },
@@ -422,6 +616,130 @@
             }
           }
         }
+      },
+      "IngestionDiagnosticEntry": {
+        "type": "object",
+        "properties": {
+          "itemId": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "example": 101
+          },
+          "feedId": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "example": 1
+          },
+          "feedTitle": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "Example Feed"
+          },
+          "itemTitle": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "Example item"
+          },
+          "canonicalUrl": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uri",
+            "example": "https://example.com/item-101"
+          },
+          "publishedAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "example": "2025-01-20T10:00:00.000Z"
+          },
+          "chosenSource": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "rss"
+          },
+          "rawDescriptionLength": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "example": 240
+          },
+          "bodyHtmlRawLength": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "example": 1280
+          },
+          "articleHtmlLength": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "example": 1100
+          },
+          "hasBlockTags": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "example": true
+          },
+          "looksEscapedHtml": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "example": false
+          },
+          "weakContent": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "example": false
+          },
+          "articleHtmlPreview": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "<p>Example</p>"
+          },
+          "recordedAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "example": "2025-01-20T10:01:30.000Z"
+          }
+        }
+      },
+      "IngestionDiagnosticsList": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IngestionDiagnosticEntry"
+            }
+          }
+        }
       }
     },
     "securitySchemes": {
@@ -589,6 +907,26 @@
             }
           }
         }
+      },
+      "UnprocessableEntity": {
+        "description": "A requisição foi bem formada, mas viola regras de negócio.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorEnvelope"
+            },
+            "example": {
+              "success": false,
+              "error": {
+                "code": "POSTS_TIME_WINDOW_DAYS_TOO_LOW",
+                "message": "posts_time_window_days must be greater than or equal to 1"
+              },
+              "meta": {
+                "requestId": "00000000-0000-4000-8000-000000000000"
+              }
+            }
+          }
+        }
       }
     }
   },
@@ -637,6 +975,38 @@
         }
       }
     },
+    "/metrics": {
+      "get": {
+        "summary": "Export Prometheus metrics",
+        "description": "Retorna as métricas coletadas em formato texto compatível com Prometheus.",
+        "tags": [
+          "Observability"
+        ],
+        "responses": {
+          "200": {
+            "description": "Métricas atuais da aplicação",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "# HELP http_requests_total Total de requisições HTTP\n# TYPE http_requests_total counter\nhttp_requests_total{method=\"get\",route=\"/health/live\",status=\"200\"} 42\n"
+              }
+            }
+          },
+          "404": {
+            "description": "Coleta de métricas desabilitada",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/allowlist": {
       "get": {
         "summary": "List allowed users with pagination",
@@ -656,7 +1026,8 @@
             "in": "query",
             "name": "cursor",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "nullable": true
             },
             "description": "Cursor retornado em respostas anteriores para continuar a paginação."
           },
@@ -685,34 +1056,837 @@
                       "type": "object",
                       "properties": {
                         "data": {
-                          "type": "object",
-                          "properties": {
-                            "items": {
-                              "type": "array",
-                              "items": {
-                                "$ref": "#/components/schemas/AllowedUser"
-                              }
-                            }
-                          }
-                        },
-                        "meta": {
-                          "type": "object",
-                          "properties": {
-                            "nextCursor": {
-                              "type": "integer",
-                              "nullable": true
-                            },
-                            "total": {
-                              "type": "integer"
-                            },
-                            "limit": {
-                              "type": "integer"
-                            }
-                          }
+                          "$ref": "#/components/schemas/AllowlistListResponse"
                         }
                       }
                     }
                   ]
+                },
+                "examples": {
+                  "success": {
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "items": [
+                          {
+                            "id": 1,
+                            "email": "admin@example.com",
+                            "role": "admin",
+                            "immutable": true,
+                            "createdAt": "2025-01-10T12:00:00.000Z",
+                            "updatedAt": "2025-01-11T09:30:00.000Z"
+                          }
+                        ]
+                      },
+                      "meta": {
+                        "requestId": "00000000-0000-4000-8000-000000000001",
+                        "nextCursor": null,
+                        "total": 1,
+                        "limit": 20
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      },
+      "post": {
+        "summary": "Add a new user to the allowlist",
+        "tags": [
+          "Allowlist"
+        ],
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AllowlistCreateRequest"
+              },
+              "examples": {
+                "create": {
+                  "value": {
+                    "email": "editor@example.com",
+                    "role": "editor"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Usuário adicionado à allowlist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Envelope"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/AllowedUser"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "examples": {
+                  "created": {
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "id": 2,
+                        "email": "editor@example.com",
+                        "role": "editor",
+                        "immutable": false,
+                        "createdAt": "2025-01-20T12:30:00.000Z",
+                        "updatedAt": "2025-01-20T12:30:00.000Z"
+                      },
+                      "meta": {
+                        "requestId": "00000000-0000-4000-8000-000000000002"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          }
+        }
+      }
+    },
+    "/api/v1/allowlist/{id}": {
+      "patch": {
+        "summary": "Update the role of an allowlisted user",
+        "tags": [
+          "Allowlist"
+        ],
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AllowlistUpdateRoleRequest"
+              },
+              "examples": {
+                "update": {
+                  "value": {
+                    "role": "admin"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Papel atualizado com sucesso",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Envelope"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/AllowedUser"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "examples": {
+                  "updated": {
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "id": 2,
+                        "email": "editor@example.com",
+                        "role": "admin",
+                        "immutable": false,
+                        "createdAt": "2025-01-20T12:30:00.000Z",
+                        "updatedAt": "2025-01-21T08:15:00.000Z"
+                      },
+                      "meta": {
+                        "requestId": "00000000-0000-4000-8000-000000000003"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Remove an allowlisted user",
+        "tags": [
+          "Allowlist"
+        ],
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Usuário removido da allowlist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Envelope"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/AllowlistRemovalResult"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "examples": {
+                  "removed": {
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "message": "Allowlist entry removed"
+                      },
+                      "meta": {
+                        "requestId": "00000000-0000-4000-8000-000000000004"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/v1/app-params": {
+      "get": {
+        "summary": "Retrieve application-wide parameters",
+        "description": "Retorna parâmetros globais utilizados por toda a aplicação, independentes do usuário autenticado.",
+        "tags": [
+          "Application Parameters"
+        ],
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Parâmetros globais atuais",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Envelope"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/AppParams"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "examples": {
+                  "default": {
+                    "summary": "Valores padrão",
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "posts_refresh_cooldown_seconds": 3600,
+                        "posts_time_window_days": 7,
+                        "updated_at": "2025-01-20T12:34:56.000Z"
+                      },
+                      "meta": {
+                        "requestId": "00000000-0000-4000-8000-000000000000"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "put": {
+        "summary": "Update application-wide parameters",
+        "description": "Permite que administradores atualizem um ou mais parâmetros globais.",
+        "tags": [
+          "Application Parameters"
+        ],
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "posts_refresh_cooldown_seconds": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "posts_time_window_days": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              },
+              "examples": {
+                "updateCooldown": {
+                  "summary": "Ajuste de cooldown",
+                  "value": {
+                    "posts_refresh_cooldown_seconds": 1800
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Parâmetros atualizados com sucesso",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Envelope"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/AppParams"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "examples": {
+                  "updated": {
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "posts_refresh_cooldown_seconds": 1800,
+                        "posts_time_window_days": 7,
+                        "updated_at": "2025-01-21T09:15:00.000Z",
+                        "updated_by": "admin@example.com"
+                      },
+                      "meta": {
+                        "requestId": "00000000-0000-4000-8000-000000000000"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Partially update application-wide parameters",
+        "tags": [
+          "Application Parameters"
+        ],
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "posts_refresh_cooldown_seconds": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "posts_time_window_days": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Parâmetros atualizados com sucesso",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Envelope"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/AppParams"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      }
+    },
+    "/api/v1/auth/login/google": {
+      "post": {
+        "summary": "Authenticate using a Google ID token",
+        "tags": [
+          "Auth"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AuthGoogleLoginRequest"
+              },
+              "examples": {
+                "login": {
+                  "value": {
+                    "idToken": "ya29.a0AfH6SMCg..."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Login realizado com sucesso",
+            "headers": {
+              "Set-Cookie": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Cookie de sessão emitido após autenticação bem-sucedida."
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Envelope"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/AuthSession"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "examples": {
+                  "success": {
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "email": "user@example.com",
+                        "role": "editor",
+                        "expiresAt": "2025-01-20T13:45:00.000Z"
+                      },
+                      "meta": {
+                        "requestId": "00000000-0000-4000-8000-000000000010"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/v1/auth/logout": {
+      "post": {
+        "summary": "Invalidate the current session",
+        "tags": [
+          "Auth"
+        ],
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Logout efetuado",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Envelope"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/AuthLogoutResult"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "examples": {
+                  "success": {
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "message": "Logged out"
+                      },
+                      "meta": {
+                        "requestId": "00000000-0000-4000-8000-000000000011"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/v1/auth/me": {
+      "get": {
+        "summary": "Retrieve the authenticated user session",
+        "tags": [
+          "Auth"
+        ],
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sessão válida",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Envelope"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/AuthSession"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "examples": {
+                  "me": {
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "email": "user@example.com",
+                        "role": "editor",
+                        "expiresAt": "2025-01-20T13:45:00.000Z"
+                      },
+                      "meta": {
+                        "requestId": "00000000-0000-4000-8000-000000000012"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/v1/auth/debug": {
+      "get": {
+        "summary": "Inspect authentication cookies (feature flag controlled)",
+        "tags": [
+          "Auth"
+        ],
+        "responses": {
+          "200": {
+            "description": "Detalhes sobre o estado de autenticação detectado",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Envelope"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/AuthDebugReport"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/v1/diagnostics/ingestion": {
+      "get": {
+        "summary": "List the most recent ingestion diagnostics",
+        "description": "Disponibiliza os últimos eventos registrados pelo pipeline de ingestão para análise operacional.",
+        "tags": [
+          "Diagnostics"
+        ],
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "description": "Quantidade máxima de eventos retornados (padrão 20)."
+          },
+          {
+            "in": "query",
+            "name": "feedId",
+            "schema": {
+              "type": "integer",
+              "nullable": true
+            },
+            "description": "Filtra eventos associados ao feed informado."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Eventos recentes do pipeline de ingestão",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Envelope"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/IngestionDiagnosticsList"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "examples": {
+                  "success": {
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "items": [
+                          {
+                            "itemId": 101,
+                            "feedId": 1,
+                            "feedTitle": "Example Feed",
+                            "itemTitle": "Example item",
+                            "canonicalUrl": "https://example.com/item-101",
+                            "publishedAt": "2025-01-20T10:00:00.000Z",
+                            "chosenSource": "rss",
+                            "rawDescriptionLength": 240,
+                            "bodyHtmlRawLength": 1280,
+                            "articleHtmlLength": 1100,
+                            "hasBlockTags": true,
+                            "looksEscapedHtml": false,
+                            "weakContent": false,
+                            "articleHtmlPreview": "<p>Example</p>",
+                            "recordedAt": "2025-01-20T10:01:30.000Z"
+                          }
+                        ]
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -1157,6 +2331,70 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/v1/feeds/reset": {
+      "post": {
+        "summary": "Reset RSS feed ingestion state",
+        "description": "Remove todas as noticias e posts derivados dos feeds e reinicia o estado de processamento. Disponivel apenas para administradores.",
+        "tags": [
+          "Feeds"
+        ],
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resultado do reset dos feeds",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Envelope"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/FeedResetResult"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Reset concluido",
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "feedsResetCount": 12,
+                        "articlesDeletedCount": 480,
+                        "postsDeletedCount": 480,
+                        "durationMs": 85
+                      },
+                      "meta": {
+                        "requestId": "11111111-2222-4333-8444-555555555555"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
           }
         }
       }

--- a/backend/prisma/migrations/20250925120000_app_params/migration.sql
+++ b/backend/prisma/migrations/20250925120000_app_params/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "public"."app_params" (
+    "id" INTEGER NOT NULL DEFAULT 1,
+    "posts_refresh_cooldown_seconds" INTEGER NOT NULL,
+    "posts_time_window_days" INTEGER NOT NULL,
+    "updated_by" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "app_params_pkey" PRIMARY KEY ("id")
+);
+

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -82,3 +82,14 @@ model Post {
   createdAt DateTime @default(now())
 }
 
+model AppParams {
+  id                          Int      @id @default(1)
+  postsRefreshCooldownSeconds Int      @map("posts_refresh_cooldown_seconds")
+  postsTimeWindowDays         Int      @map("posts_time_window_days")
+  updatedBy                   String?  @map("updated_by") @db.Text
+  createdAt                   DateTime @default(now()) @map("created_at")
+  updatedAt                   DateTime @updatedAt @map("updated_at")
+
+  @@map("app_params")
+}
+

--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -35,10 +35,27 @@ const ensureSuperAdmin = async () => {
   });
 };
 
+const ensureAppParams = async () => {
+  const existing = await prisma.appParams.findFirst();
+
+  if (existing) {
+    return existing;
+  }
+
+  return prisma.appParams.create({
+    data: {
+      id: 1,
+      postsRefreshCooldownSeconds: 3600,
+      postsTimeWindowDays: 7,
+    },
+  });
+};
+
 const run = async () => {
   try {
     await ensureHelloMessage();
     await ensureSuperAdmin();
+    await ensureAppParams();
   } catch (error) {
     console.error('Failed to seed database:', error);
     process.exitCode = 1;

--- a/backend/src/controllers/app-params.controller.js
+++ b/backend/src/controllers/app-params.controller.js
@@ -1,0 +1,34 @@
+const asyncHandler = require('../utils/async-handler');
+const appParamsService = require('../services/app-params.service');
+
+const mapToResponse = (params) => {
+  const payload = {
+    posts_refresh_cooldown_seconds: params.postsRefreshCooldownSeconds,
+    posts_time_window_days: params.postsTimeWindowDays,
+    updated_at:
+      params.updatedAt instanceof Date ? params.updatedAt.toISOString() : new Date(params.updatedAt).toISOString(),
+  };
+
+  if (params.updatedBy) {
+    payload.updated_by = params.updatedBy;
+  }
+
+  return payload;
+};
+
+const get = asyncHandler(async (req, res) => {
+  const params = await appParamsService.getAppParams();
+  return res.success(mapToResponse(params));
+});
+
+const update = asyncHandler(async (req, res) => {
+  const updates = req.validated?.body ?? {};
+  const updatedBy = req.user?.email ?? (req.user?.id != null ? String(req.user.id) : null);
+  const params = await appParamsService.updateAppParams({ updates, updatedBy });
+  return res.success(mapToResponse(params));
+});
+
+module.exports = {
+  get,
+  update,
+};

--- a/backend/src/docs/openapi.js
+++ b/backend/src/docs/openapi.js
@@ -91,6 +91,19 @@ const definition = {
           updatedAt: { type: 'string', format: 'date-time', example: '2025-01-20T12:34:56.000Z' },
         },
       },
+      AppParams: {
+        type: 'object',
+        properties: {
+          posts_refresh_cooldown_seconds: { type: 'integer', minimum: 0, example: 3600 },
+          posts_time_window_days: { type: 'integer', minimum: 1, example: 7 },
+          updated_at: {
+            type: 'string',
+            format: 'date-time',
+            example: '2025-01-20T12:34:56.000Z',
+          },
+          updated_by: { type: ['string', 'null'], example: 'admin@example.com' },
+        },
+      },
       AllowlistListResponse: {
         type: 'object',
         properties: {
@@ -549,6 +562,24 @@ const definition = {
               error: {
                 code: 'PAYLOAD_TOO_LARGE',
                 message: 'A maximum of 25 feeds can be created per request',
+              },
+              meta: {
+                requestId: '00000000-0000-4000-8000-000000000000',
+              },
+            },
+          },
+        },
+      },
+      UnprocessableEntity: {
+        description: 'A requisição foi bem formada, mas viola regras de negócio.',
+        content: {
+          'application/json': {
+            schema: { $ref: '#/components/schemas/ErrorEnvelope' },
+            example: {
+              success: false,
+              error: {
+                code: 'POSTS_TIME_WINDOW_DAYS_TOO_LOW',
+                message: 'posts_time_window_days must be greater than or equal to 1',
               },
               meta: {
                 requestId: '00000000-0000-4000-8000-000000000000',

--- a/backend/src/middlewares/validate-request.js
+++ b/backend/src/middlewares/validate-request.js
@@ -27,13 +27,15 @@ const validateRequest = ({ body, query, params } = {}) => {
       req.validated = req.validated ? { ...req.validated, ...validated } : validated;
       next();
     } catch (error) {
-      if (error?.errors && Array.isArray(error.errors)) {
+      const issues = Array.isArray(error?.issues) ? error.issues : error?.errors;
+
+      if (Array.isArray(issues)) {
         return next(
           new ApiError({
             statusCode: 400,
             code: 'INVALID_INPUT',
             message: 'Invalid input data',
-            details: { errors: formatZodIssues(error.errors) },
+            details: { errors: formatZodIssues(issues) },
           })
         );
       }

--- a/backend/src/repositories/app-params.repository.js
+++ b/backend/src/repositories/app-params.repository.js
@@ -1,0 +1,53 @@
+const { prisma } = require('../lib/prisma');
+
+const APP_PARAMS_ID = 1;
+
+const findSingleton = () => prisma.appParams.findUnique({ where: { id: APP_PARAMS_ID } });
+
+const createSingleton = ({ postsRefreshCooldownSeconds, postsTimeWindowDays, updatedBy = null }) =>
+  prisma.appParams.create({
+    data: {
+      id: APP_PARAMS_ID,
+      postsRefreshCooldownSeconds,
+      postsTimeWindowDays,
+      updatedBy,
+    },
+  });
+
+const ensureDefaultSingleton = async ({ postsRefreshCooldownSeconds, postsTimeWindowDays }) => {
+  const existing = await findSingleton();
+
+  if (existing) {
+    return existing;
+  }
+
+  return createSingleton({ postsRefreshCooldownSeconds, postsTimeWindowDays });
+};
+
+const updateSingleton = ({ postsRefreshCooldownSeconds, postsTimeWindowDays, updatedBy }) => {
+  const data = {};
+
+  if (postsRefreshCooldownSeconds !== undefined) {
+    data.postsRefreshCooldownSeconds = postsRefreshCooldownSeconds;
+  }
+
+  if (postsTimeWindowDays !== undefined) {
+    data.postsTimeWindowDays = postsTimeWindowDays;
+  }
+
+  if (updatedBy !== undefined) {
+    data.updatedBy = updatedBy;
+  }
+
+  return prisma.appParams.update({
+    where: { id: APP_PARAMS_ID },
+    data,
+  });
+};
+
+module.exports = {
+  APP_PARAMS_ID,
+  findSingleton,
+  ensureDefaultSingleton,
+  updateSingleton,
+};

--- a/backend/src/routes/v1/app-params.routes.js
+++ b/backend/src/routes/v1/app-params.routes.js
@@ -1,0 +1,147 @@
+const express = require('express');
+const appParamsController = require('../../controllers/app-params.controller');
+const { validateRequest } = require('../../middlewares/validate-request');
+const { requireRole, ROLES } = require('../../middlewares/authorization');
+const { updateAppParamsBodySchema } = require('../../schemas/app-params.schema');
+
+const router = express.Router();
+
+/**
+ * @openapi
+ * /api/v1/app-params:
+ *   get:
+ *     summary: Retrieve application-wide parameters
+ *     description: Retorna parâmetros globais utilizados por toda a aplicação, independentes do usuário autenticado.
+ *     tags:
+ *       - Application Parameters
+ *     security:
+ *       - SessionCookie: []
+ *       - BearerAuth: []
+ *     responses:
+ *       '200':
+ *         description: Parâmetros globais atuais
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Envelope'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       $ref: '#/components/schemas/AppParams'
+ *             examples:
+ *               default:
+ *                 summary: Valores padrão
+ *                 value:
+ *                   success: true
+ *                   data:
+ *                     posts_refresh_cooldown_seconds: 3600
+ *                     posts_time_window_days: 7
+ *                     updated_at: '2025-01-20T12:34:56.000Z'
+ *                   meta:
+ *                     requestId: 00000000-0000-4000-8000-000000000000
+ *       '401':
+ *         $ref: '#/components/responses/Unauthorized'
+ *   put:
+ *     summary: Update application-wide parameters
+ *     description: Permite que administradores atualizem um ou mais parâmetros globais.
+ *     tags:
+ *       - Application Parameters
+ *     security:
+ *       - SessionCookie: []
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               posts_refresh_cooldown_seconds:
+ *                 type: integer
+ *                 minimum: 0
+ *               posts_time_window_days:
+ *                 type: integer
+ *                 minimum: 1
+ *           examples:
+ *             updateCooldown:
+ *               summary: Ajuste de cooldown
+ *               value:
+ *                 posts_refresh_cooldown_seconds: 1800
+ *     responses:
+ *       '200':
+ *         description: Parâmetros atualizados com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Envelope'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       $ref: '#/components/schemas/AppParams'
+ *             examples:
+ *               updated:
+ *                 value:
+ *                   success: true
+ *                   data:
+ *                     posts_refresh_cooldown_seconds: 1800
+ *                     posts_time_window_days: 7
+ *                     updated_at: '2025-01-21T09:15:00.000Z'
+ *                     updated_by: admin@example.com
+ *                   meta:
+ *                     requestId: 00000000-0000-4000-8000-000000000000
+ *       '400':
+ *         $ref: '#/components/responses/BadRequest'
+ *       '401':
+ *         $ref: '#/components/responses/Unauthorized'
+ *       '403':
+ *         $ref: '#/components/responses/Forbidden'
+ *       '422':
+ *         $ref: '#/components/responses/UnprocessableEntity'
+ *   patch:
+ *     summary: Partially update application-wide parameters
+ *     tags:
+ *       - Application Parameters
+ *     security:
+ *       - SessionCookie: []
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               posts_refresh_cooldown_seconds:
+ *                 type: integer
+ *                 minimum: 0
+ *               posts_time_window_days:
+ *                 type: integer
+ *                 minimum: 1
+ *     responses:
+ *       '200':
+ *         description: Parâmetros atualizados com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Envelope'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       $ref: '#/components/schemas/AppParams'
+ *       '400':
+ *         $ref: '#/components/responses/BadRequest'
+ *       '401':
+ *         $ref: '#/components/responses/Unauthorized'
+ *       '403':
+ *         $ref: '#/components/responses/Forbidden'
+ *       '422':
+ *         $ref: '#/components/responses/UnprocessableEntity'
+ */
+router.get('/', appParamsController.get);
+router.put('/', requireRole(ROLES.ADMIN), validateRequest({ body: updateAppParamsBodySchema }), appParamsController.update);
+router.patch('/', requireRole(ROLES.ADMIN), validateRequest({ body: updateAppParamsBodySchema }), appParamsController.update);
+
+module.exports = router;

--- a/backend/src/routes/v1/index.js
+++ b/backend/src/routes/v1/index.js
@@ -3,6 +3,7 @@ const authRoutes = require('./auth.routes');
 const helloRoutes = require('./hello.routes');
 const feedRoutes = require('./feed.routes');
 const postsRoutes = require('./posts.routes');
+const appParamsRoutes = require('./app-params.routes');
 const allowlistRoutes = require('./allowlist.routes');
 const diagnosticsRoutes = require('./diagnostics.routes');
 const { requireAuth } = require('../../middlewares/authentication');
@@ -15,6 +16,7 @@ router.use(requireAuth);
 router.use(helloRoutes);
 router.use(feedRoutes);
 router.use(postsRoutes);
+router.use('/app-params', appParamsRoutes);
 router.use('/allowlist', requireRole(ROLES.ADMIN), allowlistRoutes);
 router.use('/diagnostics', requireRole(ROLES.ADMIN), diagnosticsRoutes);
 

--- a/backend/src/schemas/app-params.schema.js
+++ b/backend/src/schemas/app-params.schema.js
@@ -1,0 +1,20 @@
+const { z } = require('zod');
+
+const updateAppParamsBodySchema = z
+  .object({
+    posts_refresh_cooldown_seconds: z.number().int().optional(),
+    posts_time_window_days: z.number().int().optional(),
+  })
+  .strip()
+  .refine(
+    (data) =>
+      Object.hasOwn(data, 'posts_refresh_cooldown_seconds') || Object.hasOwn(data, 'posts_time_window_days'),
+    {
+      message: 'At least one property must be provided',
+      path: ['posts_refresh_cooldown_seconds'],
+    }
+  );
+
+module.exports = {
+  updateAppParamsBodySchema,
+};

--- a/backend/src/services/app-params.service.js
+++ b/backend/src/services/app-params.service.js
@@ -1,0 +1,129 @@
+const ApiError = require('../utils/api-error');
+const { Sentry } = require('../lib/sentry');
+const appParamsRepository = require('../repositories/app-params.repository');
+
+const DEFAULT_APP_PARAMS = {
+  postsRefreshCooldownSeconds: 3600,
+  postsTimeWindowDays: 7,
+};
+
+const toDomainModel = (record) => ({
+  postsRefreshCooldownSeconds: record.postsRefreshCooldownSeconds,
+  postsTimeWindowDays: record.postsTimeWindowDays,
+  updatedAt: record.updatedAt instanceof Date ? record.updatedAt : new Date(record.updatedAt),
+  updatedBy: record.updatedBy ?? null,
+});
+
+const ensureDefaultAppParams = async () => {
+  const record = await appParamsRepository.ensureDefaultSingleton(DEFAULT_APP_PARAMS);
+  return toDomainModel(record);
+};
+
+const getAppParams = () => ensureDefaultAppParams();
+
+const validateCooldown = (value) => {
+  if (!Number.isInteger(value)) {
+    throw new ApiError({
+      statusCode: 400,
+      code: 'INVALID_POSTS_REFRESH_COOLDOWN_SECONDS',
+      message: 'posts_refresh_cooldown_seconds must be an integer',
+    });
+  }
+
+  if (value < 0) {
+    throw new ApiError({
+      statusCode: 422,
+      code: 'POSTS_REFRESH_COOLDOWN_SECONDS_TOO_LOW',
+      message: 'posts_refresh_cooldown_seconds must be greater than or equal to 0',
+    });
+  }
+};
+
+const validateTimeWindow = (value) => {
+  if (!Number.isInteger(value)) {
+    throw new ApiError({
+      statusCode: 400,
+      code: 'INVALID_POSTS_TIME_WINDOW_DAYS',
+      message: 'posts_time_window_days must be an integer',
+    });
+  }
+
+  if (value < 1) {
+    throw new ApiError({
+      statusCode: 422,
+      code: 'POSTS_TIME_WINDOW_DAYS_TOO_LOW',
+      message: 'posts_time_window_days must be greater than or equal to 1',
+    });
+  }
+};
+
+const updateAppParams = async ({ updates, updatedBy }) => {
+  const current = await ensureDefaultAppParams();
+  const changes = {};
+
+  if (Object.hasOwn(updates, 'posts_refresh_cooldown_seconds')) {
+    const cooldown = updates.posts_refresh_cooldown_seconds;
+    validateCooldown(cooldown);
+    changes.postsRefreshCooldownSeconds = cooldown;
+  }
+
+  if (Object.hasOwn(updates, 'posts_time_window_days')) {
+    const windowDays = updates.posts_time_window_days;
+    validateTimeWindow(windowDays);
+    changes.postsTimeWindowDays = windowDays;
+  }
+
+  if (Object.keys(changes).length === 0) {
+    return current;
+  }
+
+  const normalizedUpdatedBy =
+    updatedBy == null || updatedBy === '' ? null : String(updatedBy).trim() || null;
+
+  const updatedRecord = await appParamsRepository.updateSingleton({
+    ...changes,
+    updatedBy: normalizedUpdatedBy,
+  });
+
+  const updated = toDomainModel(updatedRecord);
+  const changedKeys = Object.keys(changes);
+
+  const breadcrumbData = {
+    updatedBy: normalizedUpdatedBy ?? 'unknown',
+    changed: changedKeys,
+  };
+
+  try {
+    Sentry.addBreadcrumb({
+      category: 'app-params',
+      level: 'info',
+      message: 'Application parameters updated',
+      data: breadcrumbData,
+    });
+  } catch (error) {
+    console.warn('Failed to add Sentry breadcrumb for app params update', error);
+  }
+
+  const changeLog = {};
+
+  if (Object.hasOwn(updates, 'posts_refresh_cooldown_seconds')) {
+    changeLog.posts_refresh_cooldown_seconds = changes.postsRefreshCooldownSeconds;
+  }
+
+  if (Object.hasOwn(updates, 'posts_time_window_days')) {
+    changeLog.posts_time_window_days = changes.postsTimeWindowDays;
+  }
+
+  console.info('app-params updated by %s', breadcrumbData.updatedBy, {
+    changed: changeLog,
+  });
+
+  return updated;
+};
+
+module.exports = {
+  DEFAULT_APP_PARAMS,
+  ensureDefaultAppParams,
+  getAppParams,
+  updateAppParams,
+};

--- a/backend/tests/app-params.e2e.test.js
+++ b/backend/tests/app-params.e2e.test.js
@@ -1,0 +1,136 @@
+const request = require('supertest');
+
+jest.mock('../src/services/auth.service', () => {
+  const actual = jest.requireActual('../src/services/auth.service');
+  return {
+    ...actual,
+    validateSessionToken: jest.fn(),
+  };
+});
+
+const app = require('../src/app');
+const authService = require('../src/services/auth.service');
+const appParamsService = require('../src/services/app-params.service');
+const { prisma } = require('../src/lib/prisma');
+
+const ORIGIN = 'http://localhost:5173';
+const TOKENS = {
+  admin: 'token-admin',
+  user: 'token-user',
+};
+
+const sessionForUser = (userId, email, role) => ({
+  session: {
+    id: `session-${userId}`,
+    userId,
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    user: {
+      id: userId,
+      email,
+      role,
+    },
+  },
+  renewed: false,
+});
+
+const withAuth = (token, req) => req.set('Origin', ORIGIN).set('Authorization', `Bearer ${token}`);
+
+describe('Application parameters API', () => {
+  beforeEach(async () => {
+    prisma.__reset();
+
+    authService.validateSessionToken.mockImplementation(async ({ token }) => {
+      if (token === TOKENS.admin) {
+        return sessionForUser(1, 'admin@example.com', 'admin');
+      }
+
+      if (token === TOKENS.user) {
+        return sessionForUser(2, 'user@example.com', 'user');
+      }
+
+      return null;
+    });
+
+    await appParamsService.ensureDefaultAppParams();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns seeded values for authenticated users', async () => {
+    const response = await withAuth(TOKENS.user, request(app).get('/api/v1/app-params')).expect('Content-Type', /json/).expect(200);
+
+    expect(response.body.success).toBe(true);
+    expect(response.body.data).toEqual(
+      expect.objectContaining({
+        posts_refresh_cooldown_seconds: 3600,
+        posts_time_window_days: 7,
+      })
+    );
+    expect(typeof response.body.data.updated_at).toBe('string');
+    expect(response.body.data).not.toHaveProperty('updated_by');
+  });
+
+  it('allows admins to update parameters and records audit info', async () => {
+    const initial = await appParamsService.getAppParams();
+
+    const response = await withAuth(
+      TOKENS.admin,
+      request(app).put('/api/v1/app-params').send({ posts_refresh_cooldown_seconds: 1800 })
+    )
+      .expect('Content-Type', /json/)
+      .expect(200);
+
+    expect(response.body.data.posts_refresh_cooldown_seconds).toBe(1800);
+    expect(response.body.data.posts_time_window_days).toBe(7);
+    expect(response.body.data.updated_by).toBe('admin@example.com');
+
+    const updatedAt = new Date(response.body.data.updated_at).valueOf();
+    expect(Number.isNaN(updatedAt)).toBe(false);
+    expect(updatedAt).toBeGreaterThan(initial.updatedAt.valueOf());
+  });
+
+  it('rejects updates from non-admin users', async () => {
+    const response = await withAuth(TOKENS.user, request(app).patch('/api/v1/app-params').send({ posts_time_window_days: 5 }))
+      .expect('Content-Type', /json/)
+      .expect(403);
+
+    expect(response.body.error.code).toBe('FORBIDDEN');
+  });
+
+  it('enforces integer and boundary validations', async () => {
+    await withAuth(
+      TOKENS.admin,
+      request(app).put('/api/v1/app-params').send({ posts_refresh_cooldown_seconds: -1 })
+    )
+      .expect('Content-Type', /json/)
+      .expect(422);
+
+    await withAuth(
+      TOKENS.admin,
+      request(app).patch('/api/v1/app-params').send({ posts_time_window_days: 0 })
+    )
+      .expect('Content-Type', /json/)
+      .expect(422);
+
+    await withAuth(
+      TOKENS.admin,
+      request(app).patch('/api/v1/app-params').send({ posts_refresh_cooldown_seconds: 1.5 })
+    )
+      .expect('Content-Type', /json/)
+      .expect(400);
+  });
+
+  it('is idempotent when ensuring default parameters', async () => {
+    const first = await appParamsService.ensureDefaultAppParams();
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    const second = await appParamsService.ensureDefaultAppParams();
+
+    expect(second.postsRefreshCooldownSeconds).toBe(3600);
+    expect(second.postsTimeWindowDays).toBe(7);
+    expect(second.updatedAt.valueOf()).toBe(first.updatedAt.valueOf());
+  });
+});


### PR DESCRIPTION
## Summary
- add Prisma model, migration, and seed/backfill for global application parameters
- expose authenticated GET and admin-only PUT/PATCH endpoints with validation, logging, and Sentry breadcrumbs
- document the contract in Swagger and cover the new behaviour with integration tests while improving request validation handling

## Testing
- npm test
- npm run docs:generate

------
https://chatgpt.com/codex/tasks/task_e_68d56da681508325b33e6f5990dc223b