### PR TITLE
Add app parameter admin UI and cache integration

### DIFF
--- a/frontend/src/app/routes/router.tsx
+++ b/frontend/src/app/routes/router.tsx
@@ -13,6 +13,8 @@ const AllowlistPage = lazy(() => import('@/pages/allowlist/AllowlistPage'));
 const NotFoundPage = lazy(() => import('@/pages/not-found/NotFoundPage'));
 const NewsListPage = lazy(() => import('@/pages/news/NewsListPage'));
 const NewsDetailPage = lazy(() => import('@/pages/news/NewsDetailPage'));
+const AppParamsPage = lazy(() => import('@/pages/app-params/AppParamsPage'));
+const ForbiddenPage = lazy(() => import('@/pages/forbidden/ForbiddenPage'));
 
 const withSuspense = (node: ReactNode) => <Suspense fallback={<LoadingSplash />}>{node}</Suspense>;
 
@@ -62,6 +64,14 @@ export const router = createBrowserRouter([
         element: withSuspense(
           <RequireAdmin>
             <AllowlistPage />
+          </RequireAdmin>
+        ),
+      },
+      {
+        path: 'app-params',
+        element: withSuspense(
+          <RequireAdmin forbiddenElement={withSuspense(<ForbiddenPage />)}>
+            <AppParamsPage />
           </RequireAdmin>
         ),
       },

--- a/frontend/src/components/navigation/TopNav.tsx
+++ b/frontend/src/components/navigation/TopNav.tsx
@@ -18,7 +18,10 @@ export const TopNav = () => {
           { to: '/posts', label: t('navigation.posts', 'Posts') },
           { to: '/feeds', label: t('navigation.feeds', 'Feeds') },
           ...(user?.role === 'admin'
-            ? [{ to: '/allowlist', label: t('navigation.allowlist', 'Allowlist') }]
+            ? [
+                { to: '/allowlist', label: t('navigation.allowlist', 'Allowlist') },
+                { to: '/app-params', label: t('navigation.appParams', 'Parâmetros') },
+              ]
             : []),
         ]
       : [{ to: '/', label: t('navigation.home') }];

--- a/frontend/src/config/i18n.ts
+++ b/frontend/src/config/i18n.ts
@@ -13,6 +13,7 @@ const resources = {
         posts: 'Posts',
         feeds: 'Feeds',
         allowlist: 'Allowlist',
+        appParams: 'App parameters',
         skipToContent: 'Skip to content',
         signIn: 'Sign in',
         logout: 'Sign out',
@@ -156,6 +157,7 @@ const resources = {
         actions: {
           refresh: 'Refresh',
           refreshing: 'Refreshing...',
+          refreshCooldown: 'Wait {{time}} before refreshing again.',
         },
         errors: {
           generic: 'The operation failed. Try again.',
@@ -169,7 +171,7 @@ const resources = {
           syncing: 'Syncing...',
         },
         cleanup: {
-          description: 'Removed {{articles}} articles and {{posts}} posts older than seven days.',
+          description: 'Removed {{articles}} articles and {{posts}} posts older than {{days}} days.',
         },
         summary: {
           title: 'Refresh summary',
@@ -187,7 +189,7 @@ const resources = {
             seconds: '{{seconds}} s',
           },
           itemsRead: 'Items read',
-          itemsWithinWindow: 'Items within < 7d',
+          itemsWithinWindow: 'Items within < {{days}}d',
           articlesCreated: 'Articles created',
           duplicates: 'Duplicates',
           invalidItems: 'Invalid entries',
@@ -226,7 +228,7 @@ const resources = {
           empty: {
             default: {
               title: 'No recent posts.',
-              description: 'Posts from the last seven days will appear here after a refresh.',
+              description: 'Posts from the last {{days}} days will appear here after a refresh.',
             },
             filtered: {
               title: 'No posts for this feed.',
@@ -295,6 +297,46 @@ const resources = {
           },
         },
       },
+      appParams: {
+        heading: 'Application parameters',
+        subtitle: 'Adjust how posts are processed and presented across the app.',
+        fields: {
+          refreshCooldown: 'Refresh cooldown (seconds)',
+          timeWindow: 'Posts time window (days)',
+        },
+        validation: {
+          cooldownRequired: 'Enter an integer greater than or equal to zero.',
+          cooldownNegative: 'Cooldown cannot be negative.',
+          windowRequired: 'Enter an integer greater than or equal to one.',
+          windowTooSmall: 'The time window must be at least one day.',
+        },
+        feedback: {
+          successWithReset: 'Parameters updated successfully. Feeds reset based on the new configuration.',
+          successResetFailed:
+            'Parameters updated successfully, but we could not reset the feeds automatically. Try again from the feeds page.',
+          error: 'We could not update the parameters. Try again later.',
+        },
+        actions: {
+          save: 'Save',
+          saving: 'Saving...',
+          cancel: 'Cancel',
+          retry: 'Try again',
+          retrying: 'Retrying...',
+        },
+        status: {
+          refreshing: 'Syncing parameters...',
+        },
+        errors: {
+          loadFailed: 'We could not load the parameters.',
+          retry: 'Try again. If the issue persists, contact support.',
+        },
+      },
+      forbidden: {
+        title: '403 - Access denied',
+        description:
+          'You do not have permission to access this page. Contact an administrator if you need access.',
+        backToPosts: 'Back to Posts',
+      },
       notFound: {
         meta: { title: 'lkdposts - Not found' },
         title: 'Page not found',
@@ -311,6 +353,7 @@ const resources = {
         posts: 'Posts',
         feeds: 'Feeds',
         allowlist: 'Allowlist',
+        appParams: 'Parametros',
         skipToContent: 'Ir para o conteudo',
         signIn: 'Entrar',
         logout: 'Sair',
@@ -454,6 +497,7 @@ const resources = {
         actions: {
           refresh: 'Atualizar',
           refreshing: 'Atualizando...',
+          refreshCooldown: 'Aguarde {{time}} antes de atualizar novamente.',
         },
         errors: {
           generic: 'A operacao falhou. Tente novamente.',
@@ -467,7 +511,7 @@ const resources = {
           syncing: 'Sincronizando...',
         },
         cleanup: {
-          description: 'Removidos {{articles}} artigos e {{posts}} posts com mais de sete dias.',
+          description: 'Removidos {{articles}} artigos e {{posts}} posts com mais de {{days}} dias.',
         },
         summary: {
           title: 'Resumo da atualizacao',
@@ -485,7 +529,7 @@ const resources = {
             seconds: '{{seconds}} seg',
           },
           itemsRead: 'Itens lidos',
-          itemsWithinWindow: 'Itens dentro de < 7d',
+          itemsWithinWindow: 'Itens dentro de < {{days}}d',
           articlesCreated: 'Artigos criados',
           duplicates: 'Duplicatas',
           invalidItems: 'Entradas invalidas',
@@ -524,7 +568,7 @@ const resources = {
           empty: {
             default: {
               title: 'Nenhum post recente.',
-              description: 'Posts dos ultimos sete dias aparecerao aqui apos uma atualizacao.',
+              description: 'Posts dos ultimos {{days}} dias aparecerao aqui apos uma atualizacao.',
             },
             filtered: {
               title: 'Nenhum post para este feed.',
@@ -592,6 +636,46 @@ const resources = {
             actions: 'Acoes',
           },
         },
+      },
+      appParams: {
+        heading: 'Parametros da aplicacao',
+        subtitle: 'Ajuste os valores que controlam o processamento e a exibicao dos posts.',
+        fields: {
+          refreshCooldown: 'Cooldown de atualizacao (segundos)',
+          timeWindow: 'Janela de tempo dos posts (dias)',
+        },
+        validation: {
+          cooldownRequired: 'Informe um numero inteiro maior ou igual a zero.',
+          cooldownNegative: 'O cooldown nao pode ser negativo.',
+          windowRequired: 'Informe um numero inteiro maior ou igual a um.',
+          windowTooSmall: 'A janela de tempo deve ter pelo menos um dia.',
+        },
+        feedback: {
+          successWithReset: 'Parametros atualizados com sucesso. Feeds resetados com base nos novos parametros.',
+          successResetFailed:
+            'Parametros atualizados com sucesso, mas nao foi possivel resetar os feeds automaticamente. Tente novamente na tela de feeds.',
+          error: 'Nao foi possivel atualizar os parametros. Tente novamente mais tarde.',
+        },
+        actions: {
+          save: 'Salvar',
+          saving: 'Salvando...',
+          cancel: 'Cancelar',
+          retry: 'Tentar novamente',
+          retrying: 'Tentando novamente...',
+        },
+        status: {
+          refreshing: 'Sincronizando parametros...',
+        },
+        errors: {
+          loadFailed: 'Nao foi possivel carregar os parametros.',
+          retry: 'Tente novamente. Se o problema persistir, contate o suporte.',
+        },
+      },
+      forbidden: {
+        title: '403 - Acesso negado',
+        description:
+          'Voce nao tem permissao para acessar esta pagina. Verifique com um administrador se precisar de acesso.',
+        backToPosts: 'Voltar para Posts',
       },
       notFound: {
         meta: { title: 'lkdposts - Nao encontrado' },

--- a/frontend/src/features/app-params/api/appParams.ts
+++ b/frontend/src/features/app-params/api/appParams.ts
@@ -1,0 +1,16 @@
+import { getJson, patchJson, putJson } from '@/lib/api/http';
+import { appParamsSchema, type AppParams, type AppParamsUpdateInput } from '../types/appParams';
+
+const APP_PARAMS_ENDPOINT = '/api/v1/app-params';
+
+export const fetchAppParams = () => {
+  return getJson<AppParams>(APP_PARAMS_ENDPOINT, appParamsSchema);
+};
+
+export const updateAppParams = (payload: AppParamsUpdateInput, method: 'PUT' | 'PATCH' = 'PATCH') => {
+  if (method === 'PUT') {
+    return putJson<AppParams, AppParamsUpdateInput>(APP_PARAMS_ENDPOINT, payload, appParamsSchema);
+  }
+
+  return patchJson<AppParams, AppParamsUpdateInput>(APP_PARAMS_ENDPOINT, payload, appParamsSchema);
+};

--- a/frontend/src/features/app-params/context/AppParamsContext.tsx
+++ b/frontend/src/features/app-params/context/AppParamsContext.tsx
@@ -1,0 +1,236 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+
+import { fetchAppParams, updateAppParams } from '../api/appParams';
+import { type AppParams, type AppParamsUpdateInput } from '../types/appParams';
+import {
+  clearAppParamsCache,
+  getAppParamsStorageKey,
+  readAppParamsCache,
+  writeAppParamsCache,
+} from '../storage/appParamsStorage';
+import { useAuth } from '@/features/auth/hooks/useAuth';
+import { HttpError } from '@/lib/api/http';
+
+const ONE_HOUR_IN_MS = 60 * 60 * 1000;
+
+type AppParamsStatus = 'idle' | 'loading' | 'success' | 'error';
+
+type RefreshOptions = {
+  force?: boolean;
+};
+
+type AppParamsContextValue = {
+  params: AppParams | null;
+  status: AppParamsStatus;
+  error: unknown;
+  isFetching: boolean;
+  fetchedAt: number | null;
+  refresh: (options?: RefreshOptions) => Promise<AppParams | null>;
+  update: (changes: AppParamsUpdateInput) => Promise<AppParams>;
+  clearError: () => void;
+};
+
+const AppParamsContext = createContext<AppParamsContextValue | undefined>(undefined);
+
+const isCacheExpired = (fetchedAt: number) => Date.now() - fetchedAt >= ONE_HOUR_IN_MS;
+
+export const AppParamsProvider = ({ children }: { children: ReactNode }) => {
+  const { status: authStatus } = useAuth();
+  const [params, setParams] = useState<AppParams | null>(null);
+  const [status, setStatus] = useState<AppParamsStatus>('idle');
+  const [error, setError] = useState<unknown>(null);
+  const [isFetching, setIsFetching] = useState(false);
+  const [fetchedAt, setFetchedAt] = useState<number | null>(null);
+  const hasInitialisedRef = useRef(false);
+
+  const applyParams = useCallback((nextParams: AppParams, nextFetchedAt: number) => {
+    setParams(nextParams);
+    setFetchedAt(nextFetchedAt);
+    setStatus('success');
+    setError(null);
+  }, []);
+
+  const handleFetchError = useCallback(
+    (fetchError: unknown, hasCachedValue: boolean) => {
+      if (fetchError instanceof HttpError && fetchError.status === 401) {
+        // Let auth flow handle unauthorized errors
+        return;
+      }
+
+      setError(fetchError);
+      if (!hasCachedValue) {
+        setStatus('error');
+      }
+    },
+    [],
+  );
+
+  const fetchAndApply = useCallback(async () => {
+    const response = await fetchAppParams();
+    const timestamp = Date.now();
+    writeAppParamsCache(response, timestamp);
+    applyParams(response, timestamp);
+    return response;
+  }, [applyParams]);
+
+  const refresh = useCallback<Required<AppParamsContextValue>['refresh']>(
+    async (options = {}) => {
+      if (authStatus !== 'authenticated') {
+        return null;
+      }
+
+      const cached = readAppParamsCache();
+      const hasCachedValue = Boolean(cached);
+      const shouldUseCache = cached && !options.force && !isCacheExpired(cached.fetchedAt);
+
+      if (shouldUseCache) {
+        applyParams(cached.value, cached.fetchedAt);
+        return cached.value;
+      }
+
+      setIsFetching(true);
+      try {
+        return await fetchAndApply();
+      } catch (fetchError) {
+        handleFetchError(fetchError, hasCachedValue);
+        throw fetchError;
+      } finally {
+        setIsFetching(false);
+      }
+    },
+    [applyParams, authStatus, fetchAndApply, handleFetchError],
+  );
+
+  const update = useCallback<Required<AppParamsContextValue>['update']>(
+    async (changes) => {
+      const response = await updateAppParams(changes);
+      const timestamp = Date.now();
+      writeAppParamsCache(response, timestamp);
+      applyParams(response, timestamp);
+      return response;
+    },
+    [applyParams],
+  );
+
+  useEffect(() => {
+    if (authStatus !== 'authenticated') {
+      if (authStatus === 'guest') {
+        clearAppParamsCache();
+      }
+      hasInitialisedRef.current = false;
+      setParams(null);
+      setFetchedAt(null);
+      setStatus('idle');
+      setError(null);
+      setIsFetching(false);
+      return;
+    }
+
+    if (hasInitialisedRef.current) {
+      return;
+    }
+
+    hasInitialisedRef.current = true;
+
+    const cached = readAppParamsCache();
+    if (cached) {
+      applyParams(cached.value, cached.fetchedAt);
+    } else {
+      setStatus('loading');
+    }
+
+    const shouldFetch = !cached || isCacheExpired(cached.fetchedAt);
+
+    if (!shouldFetch) {
+      return;
+    }
+
+    let isActive = true;
+    setIsFetching(true);
+
+    fetchAndApply()
+      .catch((fetchError) => {
+        if (!isActive) {
+          return;
+        }
+        handleFetchError(fetchError, Boolean(cached));
+      })
+      .finally(() => {
+        if (!isActive) {
+          return;
+        }
+        setIsFetching(false);
+      });
+
+    return () => {
+      isActive = false;
+    };
+  }, [applyParams, authStatus, fetchAndApply, handleFetchError]);
+
+  useEffect(() => {
+    const browserWindow = 'window' in globalThis ? globalThis.window : undefined;
+    if (!browserWindow) {
+      return;
+    }
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.storageArea !== browserWindow.localStorage) {
+        return;
+      }
+
+      if (event.key !== getAppParamsStorageKey()) {
+        return;
+      }
+
+      const cached = readAppParamsCache();
+
+      if (!cached) {
+        if (authStatus === 'authenticated') {
+          setParams(null);
+          setFetchedAt(null);
+          setStatus('idle');
+        }
+        return;
+      }
+
+      applyParams(cached.value, cached.fetchedAt);
+    };
+
+    browserWindow.addEventListener('storage', handleStorage);
+    return () => {
+      browserWindow.removeEventListener('storage', handleStorage);
+    };
+  }, [applyParams, authStatus]);
+
+  const clearError = useCallback(() => {
+    setError(null);
+    if (!params) {
+      setStatus('idle');
+    }
+  }, [params]);
+
+  const value = useMemo<AppParamsContextValue>(
+    () => ({ params, status, error, isFetching, fetchedAt, refresh, update, clearError }),
+    [params, status, error, isFetching, fetchedAt, refresh, update, clearError],
+  );
+
+  return <AppParamsContext.Provider value={value}>{children}</AppParamsContext.Provider>;
+};
+
+export const useAppParamsContext = () => {
+  const context = useContext(AppParamsContext);
+  if (!context) {
+    throw new Error('useAppParamsContext must be used within an AppParamsProvider');
+  }
+
+  return context;
+};

--- a/frontend/src/features/app-params/hooks/useAppParams.ts
+++ b/frontend/src/features/app-params/hooks/useAppParams.ts
@@ -1,0 +1,5 @@
+import { useAppParamsContext } from '../context/AppParamsContext';
+
+export const useAppParams = () => {
+  return useAppParamsContext();
+};

--- a/frontend/src/features/app-params/storage/appParamsStorage.ts
+++ b/frontend/src/features/app-params/storage/appParamsStorage.ts
@@ -1,0 +1,79 @@
+import { type AppParams } from '../types/appParams';
+
+const STORAGE_KEY = 'lkdposts:app-params';
+
+export type AppParamsCacheEntry = {
+  value: AppParams;
+  fetchedAt: number;
+};
+
+const getStorage = () => {
+  if (!('window' in globalThis)) {
+    return undefined;
+  }
+
+  try {
+    return globalThis.window.localStorage;
+  } catch {
+    return undefined;
+  }
+};
+
+export const readAppParamsCache = (): AppParamsCacheEntry | null => {
+  const storage = getStorage();
+  if (!storage) {
+    return null;
+  }
+
+  const raw = storage.getItem(STORAGE_KEY);
+
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as { value: AppParams; fetchedAt: number };
+    if (!parsed || typeof parsed !== 'object') {
+      return null;
+    }
+
+    if (typeof parsed.fetchedAt !== 'number') {
+      return null;
+    }
+
+    return {
+      value: parsed.value,
+      fetchedAt: parsed.fetchedAt,
+    };
+  } catch {
+    return null;
+  }
+};
+
+export const writeAppParamsCache = (value: AppParams, fetchedAt: number) => {
+  const storage = getStorage();
+  if (!storage) {
+    return;
+  }
+
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify({ value, fetchedAt } satisfies AppParamsCacheEntry));
+  } catch {
+    // ignore storage errors
+  }
+};
+
+export const clearAppParamsCache = () => {
+  const storage = getStorage();
+  if (!storage) {
+    return;
+  }
+
+  try {
+    storage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore storage errors
+  }
+};
+
+export const getAppParamsStorageKey = () => STORAGE_KEY;

--- a/frontend/src/features/app-params/types/appParams.ts
+++ b/frontend/src/features/app-params/types/appParams.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const appParamsSchema = z.object({
+  posts_refresh_cooldown_seconds: z.number().int().nonnegative(),
+  posts_time_window_days: z.number().int().min(1),
+  updated_at: z.string(),
+  updated_by: z.string().nullable().optional(),
+});
+
+export type AppParams = z.infer<typeof appParamsSchema>;
+
+export type AppParamsUpdateInput = Partial<
+  Pick<AppParams, 'posts_refresh_cooldown_seconds' | 'posts_time_window_days'>
+>;

--- a/frontend/src/features/auth/components/RequireAdmin.tsx
+++ b/frontend/src/features/auth/components/RequireAdmin.tsx
@@ -6,9 +6,10 @@ import { useAuth } from '../hooks/useAuth';
 
 type RequireAdminProps = {
   children: React.ReactElement;
+  forbiddenElement?: React.ReactElement;
 };
 
-export const RequireAdmin: React.FC<RequireAdminProps> = ({ children }) => {
+export const RequireAdmin: React.FC<RequireAdminProps> = ({ children, forbiddenElement }) => {
   const { status, user } = useAuth();
   const location = useLocation();
 
@@ -21,6 +22,9 @@ export const RequireAdmin: React.FC<RequireAdminProps> = ({ children }) => {
   }
 
   if (!user || user.role !== 'admin') {
+    if (forbiddenElement) {
+      return forbiddenElement;
+    }
     return <Navigate to="/posts" replace />;
   }
 

--- a/frontend/src/features/auth/context/AuthContext.tsx
+++ b/frontend/src/features/auth/context/AuthContext.tsx
@@ -10,6 +10,7 @@ import {
   type AuthSession,
 } from '../api/auth';
 import { ALLOWLIST_QUERY_KEY } from '@/features/allowlist/api/allowlist';
+import { clearAppParamsCache } from '@/features/app-params/storage/appParamsStorage';
 import { onUnauthorized } from '@/lib/api/http';
 
 const GUEST_SESSION: AuthSession = { authenticated: false, user: null };
@@ -51,6 +52,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     queryClient.invalidateQueries({ queryKey: ALLOWLIST_QUERY_KEY }).catch(() => {
       // ignore cache errors
     });
+    clearAppParamsCache();
   }, [queryClient]);
 
   useEffect(() => {
@@ -58,6 +60,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       applySession(GUEST_SESSION);
       setIsAuthenticating(false);
       setAuthError(null);
+      clearAppParamsCache();
       queryClient.clear();
     });
 
@@ -146,6 +149,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       setIsAuthenticating(false);
       setAuthError(null);
       applySession(GUEST_SESSION);
+      clearAppParamsCache();
       queryClient.clear();
     }
   }, [applySession, queryClient]);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,6 +6,7 @@ import { I18nextProvider } from 'react-i18next';
 
 import App from './app/App';
 import { AuthProvider } from './features/auth/context/AuthContext';
+import { AppParamsProvider } from './features/app-params/context/AppParamsContext';
 import { ENV } from './config/env';
 import i18n from './config/i18n';
 import { HttpError } from './lib/api/http';
@@ -105,7 +106,9 @@ ReactDOM.createRoot(rootElement).render(
       <I18nextProvider i18n={i18n}>
         <QueryClientProvider client={queryClient}>
           <AuthProvider>
-            <App />
+            <AppParamsProvider>
+              <App />
+            </AppParamsProvider>
           </AuthProvider>
         </QueryClientProvider>
       </I18nextProvider>

--- a/frontend/src/pages/app-params/AppParamsPage.test.tsx
+++ b/frontend/src/pages/app-params/AppParamsPage.test.tsx
@@ -1,0 +1,243 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { I18nextProvider } from 'react-i18next';
+import { vi } from 'vitest';
+
+import AppParamsPage from './AppParamsPage';
+import { useAppParams } from '@/features/app-params/hooks/useAppParams';
+import type { AppParams } from '@/features/app-params/types/appParams';
+import { useResetFeeds } from '@/features/feeds/hooks/useFeeds';
+import i18n from '@/config/i18n';
+import { HttpError } from '@/lib/api/http';
+
+vi.mock('@/features/app-params/hooks/useAppParams');
+vi.mock('@/features/feeds/hooks/useFeeds');
+
+const mockedUseAppParams = vi.mocked(useAppParams);
+const mockedUseResetFeeds = vi.mocked(useResetFeeds);
+
+const renderPage = () =>
+  render(
+    <I18nextProvider i18n={i18n}>
+      <AppParamsPage />
+    </I18nextProvider>,
+  );
+
+const buildAppParams = (override: Partial<AppParams> = {}): AppParams => ({
+  posts_refresh_cooldown_seconds: override.posts_refresh_cooldown_seconds ?? 0,
+  posts_time_window_days: override.posts_time_window_days ?? 7,
+  updated_at: override.updated_at ?? '2024-01-01T00:00:00.000Z',
+  updated_by: Object.hasOwn(override, 'updated_by') ? override.updated_by ?? null : 'admin@example.com',
+});
+
+const buildAppParamsHook = (
+  paramsOverride: Partial<AppParams> = {},
+  overrides: Partial<ReturnType<typeof useAppParams>> = {},
+): ReturnType<typeof useAppParams> => {
+  const params = buildAppParams(paramsOverride);
+
+  return {
+    params,
+    status: 'success',
+    error: null,
+    isFetching: false,
+    fetchedAt: Date.now(),
+    refresh: vi.fn(async () => params),
+    update: vi.fn(async () => params),
+    clearError: vi.fn(),
+    ...overrides,
+  };
+};
+
+const createResetFeedsMock = () => ({
+  mutateAsync: vi.fn(() =>
+    Promise.resolve({
+      feedsResetCount: 1,
+      articlesDeletedCount: 0,
+      postsDeletedCount: 0,
+      durationMs: 0,
+    }),
+  ),
+});
+
+describe('AppParamsPage', () => {
+  let resetFeedsMock: ReturnType<typeof createResetFeedsMock>;
+
+  beforeEach(() => {
+    resetFeedsMock = createResetFeedsMock();
+    mockedUseResetFeeds.mockReturnValue(resetFeedsMock as unknown as ReturnType<typeof useResetFeeds>);
+    mockedUseAppParams.mockReturnValue(buildAppParamsHook());
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders loading state while parameters are being fetched', () => {
+    mockedUseAppParams.mockReturnValue(
+      buildAppParamsHook({}, {
+        params: null,
+        status: 'loading',
+        isFetching: true,
+      }),
+    );
+
+    renderPage();
+
+    expect(screen.getAllByTestId('loading-skeleton').length).toBeGreaterThan(0);
+  });
+
+  it('shows an error state when parameters cannot be loaded', async () => {
+    const refreshMock = vi.fn(async () => buildAppParams());
+    mockedUseAppParams.mockReturnValue(
+      buildAppParamsHook({}, {
+        params: null,
+        status: 'error',
+        error: new HttpError('Erro', 500),
+        isFetching: false,
+        refresh: refreshMock,
+      }),
+    );
+
+    const user = userEvent.setup();
+
+    renderPage();
+
+    expect(screen.getByText('Nao foi possivel carregar os parametros.')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Tentar novamente' }));
+
+    expect(refreshMock).toHaveBeenCalledWith({ force: true });
+  });
+
+  it('displays current values and keeps save disabled when unchanged', () => {
+    renderPage();
+
+    const cooldownInput = screen.getByLabelText('Cooldown de atualizacao (segundos)');
+    const timeWindowInput = screen.getByLabelText('Janela de tempo dos posts (dias)');
+    const saveButton = screen.getByRole('button', { name: 'Salvar' });
+
+    expect(cooldownInput).toHaveValue(0);
+    expect(timeWindowInput).toHaveValue(7);
+    expect(saveButton).toBeDisabled();
+  });
+
+  it('validates integer-only inputs and prevents submission when invalid', async () => {
+    const user = userEvent.setup();
+
+    renderPage();
+
+    const cooldownInput = screen.getByLabelText('Cooldown de atualizacao (segundos)');
+    const timeWindowInput = screen.getByLabelText('Janela de tempo dos posts (dias)');
+
+    await user.clear(cooldownInput);
+    await user.type(cooldownInput, '-1');
+    await user.clear(timeWindowInput);
+    await user.type(timeWindowInput, '0');
+
+    expect(screen.getByText('O cooldown nao pode ser negativo.')).toBeInTheDocument();
+    expect(screen.getByText('A janela de tempo deve ter pelo menos um dia.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Salvar' })).toBeDisabled();
+  });
+
+  it('updates parameters and triggers feed reset on successful save', async () => {
+    const updatedParams = buildAppParams({ posts_refresh_cooldown_seconds: 120, posts_time_window_days: 5 });
+    const updateMock = vi.fn(async () => updatedParams);
+    mockedUseAppParams.mockReturnValue(buildAppParamsHook({}, { update: updateMock }));
+
+    const user = userEvent.setup();
+
+    renderPage();
+
+    const cooldownInput = screen.getByLabelText('Cooldown de atualizacao (segundos)');
+    const timeWindowInput = screen.getByLabelText('Janela de tempo dos posts (dias)');
+    const saveButton = screen.getByRole('button', { name: 'Salvar' });
+
+    await user.clear(cooldownInput);
+    await user.type(cooldownInput, '120');
+    await user.clear(timeWindowInput);
+    await user.type(timeWindowInput, '5');
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(updateMock).toHaveBeenCalledWith({
+        posts_refresh_cooldown_seconds: 120,
+        posts_time_window_days: 5,
+      });
+    });
+
+    expect(resetFeedsMock.mutateAsync).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByText(
+        'Parametros atualizados com sucesso. Feeds resetados com base nos novos parametros.',
+      ),
+    ).toBeInTheDocument();
+    expect(cooldownInput).toHaveValue(120);
+    expect(timeWindowInput).toHaveValue(5);
+  });
+
+  it('shows a warning when the feed reset fails after saving', async () => {
+    const updatedParams = buildAppParams({ posts_refresh_cooldown_seconds: 90, posts_time_window_days: 4 });
+    const updateMock = vi.fn(async () => updatedParams);
+    resetFeedsMock.mutateAsync.mockRejectedValueOnce(new Error('reset failed'));
+    mockedUseAppParams.mockReturnValue(buildAppParamsHook({}, { update: updateMock }));
+
+    const user = userEvent.setup();
+
+    renderPage();
+
+    const cooldownInput = screen.getByLabelText('Cooldown de atualizacao (segundos)');
+    const timeWindowInput = screen.getByLabelText('Janela de tempo dos posts (dias)');
+
+    await user.clear(cooldownInput);
+    await user.type(cooldownInput, '90');
+    await user.clear(timeWindowInput);
+    await user.type(timeWindowInput, '4');
+    await user.click(screen.getByRole('button', { name: 'Salvar' }));
+
+    await waitFor(() => {
+      expect(updateMock).toHaveBeenCalled();
+    });
+
+    expect(
+      screen.getByText(
+        'Parametros atualizados com sucesso, mas nao foi possivel resetar os feeds automaticamente. Tente novamente na tela de feeds.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('displays an error message when the update request fails', async () => {
+    const updateMock = vi.fn(async () => {
+      throw new HttpError('Acesso negado', 403);
+    });
+    mockedUseAppParams.mockReturnValue(buildAppParamsHook({}, { update: updateMock }));
+
+    const user = userEvent.setup();
+
+    renderPage();
+
+    const cooldownInput = screen.getByLabelText('Cooldown de atualizacao (segundos)');
+    await user.clear(cooldownInput);
+    await user.type(cooldownInput, '30');
+    await user.click(screen.getByRole('button', { name: 'Salvar' }));
+
+    await waitFor(() => {
+      expect(updateMock).toHaveBeenCalled();
+    });
+
+    expect(screen.getByText('Acesso negado')).toBeInTheDocument();
+  });
+
+  it('surfaces background refresh errors while keeping the form available', () => {
+    mockedUseAppParams.mockReturnValue(
+      buildAppParamsHook({}, {
+        error: new HttpError('Acesso negado', 403),
+      }),
+    );
+
+    renderPage();
+
+    expect(screen.getByText('Acesso negado')).toBeInTheDocument();
+    expect(screen.getByLabelText('Cooldown de atualizacao (segundos)')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/forbidden/ForbiddenPage.tsx
+++ b/frontend/src/pages/forbidden/ForbiddenPage.tsx
@@ -1,0 +1,30 @@
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+const ForbiddenPage = () => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <div className="card max-w-md space-y-4 px-6 py-8 text-center">
+        <h1 className="text-2xl font-semibold text-foreground">
+          {t('forbidden.title', '403 - Acesso negado')}
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          {t(
+            'forbidden.description',
+            'Você não tem permissão para acessar esta página. Verifique com um administrador se precisar de acesso.',
+          )}
+        </p>
+        <Link
+          to="/posts"
+          className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90"
+        >
+          {t('forbidden.backToPosts', 'Voltar para Posts')}
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default ForbiddenPage;


### PR DESCRIPTION
## Summary
- add an app parameters module with localStorage caching, provider and logout handling
- build the admin-only Application Parameters screen with validation, sentry breadcrumbs and feed reset integration
- wire posts, navigation and routing to use configurable cooldown/time window values

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d571bda39c8325b58287eaf4896745