### PR TITLE
feat(frontend): add prompts management page

### DIFF
--- a/frontend/src/app/routes/router.tsx
+++ b/frontend/src/app/routes/router.tsx
@@ -9,6 +9,7 @@ import { RequireAuth } from '@/features/auth/components/RequireAuth';
 const HomePage = lazy(() => import('@/pages/home/HomePage'));
 const FeedsPage = lazy(() => import('@/pages/feeds/FeedsPage'));
 const PostsPage = lazy(() => import('@/pages/posts/PostsPage'));
+const PromptsPage = lazy(() => import('@/pages/prompts/PromptsPage'));
 const AllowlistPage = lazy(() => import('@/pages/allowlist/AllowlistPage'));
 const NotFoundPage = lazy(() => import('@/pages/not-found/NotFoundPage'));
 const NewsListPage = lazy(() => import('@/pages/news/NewsListPage'));
@@ -40,6 +41,14 @@ export const router = createBrowserRouter([
         element: withSuspense(
           <RequireAuth>
             <PostsPage />
+          </RequireAuth>
+        ),
+      },
+      {
+        path: 'prompts',
+        element: withSuspense(
+          <RequireAuth>
+            <PromptsPage />
           </RequireAuth>
         ),
       },

--- a/frontend/src/components/navigation/TopNav.tsx
+++ b/frontend/src/components/navigation/TopNav.tsx
@@ -16,6 +16,7 @@ export const TopNav = () => {
     status === 'authenticated'
       ? [
           { to: '/posts', label: t('navigation.posts', 'Posts') },
+          { to: '/prompts', label: t('navigation.prompts', 'Prompts') },
           { to: '/feeds', label: t('navigation.feeds', 'Feeds') },
           ...(user?.role === 'admin'
             ? [

--- a/frontend/src/config/i18n.ts
+++ b/frontend/src/config/i18n.ts
@@ -11,6 +11,7 @@ const resources = {
         primary: 'Primary navigation',
         home: 'Home',
         posts: 'Posts',
+        prompts: 'Prompts',
         feeds: 'Feeds',
         allowlist: 'Allowlist',
         appParams: 'App parameters',
@@ -39,6 +40,56 @@ const resources = {
       },
       actions: {
         tryAgain: 'Try again',
+      },
+      prompts: {
+        meta: { title: 'lkdposts - Prompts' },
+        heading: 'Prompts',
+        subtitle: 'Manage the prompts used to generate your content.',
+        actions: {
+          new: 'New prompt',
+          createFirst: 'Create prompt',
+          cancel: 'Cancel',
+          edit: 'Edit',
+          delete: 'Delete',
+          deleting: 'Deleting...',
+          retry: 'Try again',
+        },
+        form: {
+          createTitle: 'Create prompt',
+          editTitle: 'Edit prompt',
+          titleLabel: 'Title',
+          contentLabel: 'Content',
+          save: 'Save prompt',
+          saving: 'Saving...',
+          errors: {
+            titleRequired: 'Enter a title.',
+            titleMax: 'Title must be 120 characters or fewer.',
+            contentRequired: 'Enter the prompt content.',
+          },
+        },
+        list: {
+          error: 'We could not load the prompts. Try again.',
+          reorderHint: 'Drag the handle or card to change the order.',
+          dragLabel: 'Drag to reposition this prompt.',
+        },
+        empty: {
+          title: 'No prompt registered yet.',
+          description: 'Create your first prompt to get started.',
+        },
+        feedback: {
+          created: 'Prompt created successfully.',
+          updated: 'Prompt updated successfully.',
+          deleted: 'Prompt deleted successfully.',
+          reordered: 'Prompt order updated.',
+          error: 'The operation failed. Try again.',
+        },
+        delete: {
+          confirm: 'Are you sure you want to delete this prompt?',
+        },
+        reorder: {
+          pending: 'Updating order...',
+          error: 'We could not reorder the prompts. Try again.',
+        },
       },
       feeds: {
         meta: { title: 'lkdposts - Feeds' },
@@ -357,6 +408,7 @@ const resources = {
         primary: 'Navegacao principal',
         home: 'Inicio',
         posts: 'Posts',
+        prompts: 'Prompts',
         feeds: 'Feeds',
         allowlist: 'Allowlist',
         appParams: 'Parametros',
@@ -385,6 +437,56 @@ const resources = {
       },
       actions: {
         tryAgain: 'Tentar novamente',
+      },
+      prompts: {
+        meta: { title: 'lkdposts - Prompts' },
+        heading: 'Prompts',
+        subtitle: 'Gerencie os prompts usados para gerar o conteudo.',
+        actions: {
+          new: 'Novo prompt',
+          createFirst: 'Criar prompt',
+          cancel: 'Cancelar',
+          edit: 'Editar',
+          delete: 'Excluir',
+          deleting: 'Excluindo...',
+          retry: 'Tentar novamente',
+        },
+        form: {
+          createTitle: 'Criar prompt',
+          editTitle: 'Editar prompt',
+          titleLabel: 'Titulo',
+          contentLabel: 'Conteudo',
+          save: 'Salvar prompt',
+          saving: 'Salvando...',
+          errors: {
+            titleRequired: 'Informe um titulo.',
+            titleMax: 'O titulo deve ter no maximo 120 caracteres.',
+            contentRequired: 'Informe o conteudo do prompt.',
+          },
+        },
+        list: {
+          error: 'Nao foi possivel carregar os prompts. Tente novamente.',
+          reorderHint: 'Arraste o card ou o manipulador para alterar a ordem.',
+          dragLabel: 'Arraste para reposicionar este prompt.',
+        },
+        empty: {
+          title: 'Nenhum prompt cadastrado ainda.',
+          description: 'Crie seu primeiro prompt para comecar.',
+        },
+        feedback: {
+          created: 'Prompt criado com sucesso.',
+          updated: 'Prompt atualizado com sucesso.',
+          deleted: 'Prompt excluido com sucesso.',
+          reordered: 'Ordem dos prompts atualizada.',
+          error: 'A operacao falhou. Tente novamente.',
+        },
+        delete: {
+          confirm: 'Tem certeza de que deseja excluir este prompt?',
+        },
+        reorder: {
+          pending: 'Atualizando ordem...',
+          error: 'Nao foi possivel reordenar os prompts. Tente novamente.',
+        },
       },
       feeds: {
         meta: { title: 'lkdposts - Feeds' },

--- a/frontend/src/features/prompts/api/prompts.ts
+++ b/frontend/src/features/prompts/api/prompts.ts
@@ -1,0 +1,38 @@
+import { deleteJson, getJson, patchJson, postJson, putJson } from '@/lib/api/http';
+import { promptListSchema, promptSchema, type Prompt, type PromptList, type PromptReorderItem } from '../types/prompt';
+
+export const PROMPTS_QUERY_KEY = ['prompts'] as const;
+
+type CreatePromptPayload = {
+  title: string;
+  content: string;
+};
+
+type UpdatePromptPayload = {
+  title: string;
+  content: string;
+};
+
+type ReorderPayload = {
+  items: PromptReorderItem[];
+};
+
+export const fetchPrompts = () => {
+  return getJson<PromptList>('/api/prompts', promptListSchema);
+};
+
+export const createPrompt = (payload: CreatePromptPayload) => {
+  return postJson<Prompt, CreatePromptPayload>('/api/prompts', payload, promptSchema);
+};
+
+export const updatePrompt = (id: number, payload: UpdatePromptPayload) => {
+  return patchJson<Prompt, UpdatePromptPayload>(`/api/prompts/${id}`, payload, promptSchema);
+};
+
+export const deletePrompt = (id: number) => {
+  return deleteJson<{ message?: string }>(`/api/prompts/${id}`);
+};
+
+export const reorderPrompts = (payload: ReorderPayload) => {
+  return putJson<Record<string, unknown>, ReorderPayload>('/api/prompts/reorder', payload);
+};

--- a/frontend/src/features/prompts/hooks/usePrompts.ts
+++ b/frontend/src/features/prompts/hooks/usePrompts.ts
@@ -1,0 +1,103 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+  createPrompt,
+  deletePrompt,
+  fetchPrompts,
+  reorderPrompts,
+  updatePrompt,
+  PROMPTS_QUERY_KEY,
+} from '../api/prompts';
+import type { Prompt, PromptList } from '../types/prompt';
+import { HttpError } from '@/lib/api/http';
+import { useAuth } from '@/features/auth/hooks/useAuth';
+
+const sortPrompts = (items: PromptList) => {
+  return [...items].sort((a, b) => a.position - b.position || a.id - b.id);
+};
+
+export const usePromptList = () => {
+  const { status } = useAuth();
+  const enabled = status === 'authenticated';
+
+  return useQuery<PromptList, HttpError>({
+    queryKey: PROMPTS_QUERY_KEY,
+    queryFn: fetchPrompts,
+    enabled,
+    select: sortPrompts,
+  });
+};
+
+export const useCreatePrompt = () => {
+  const queryClient = useQueryClient();
+  return useMutation<Prompt, HttpError, { title: string; content: string }>({
+    mutationFn: ({ title, content }) => createPrompt({ title, content }),
+    onSuccess: (created) => {
+      queryClient.setQueryData<PromptList | undefined>(PROMPTS_QUERY_KEY, (current) => {
+        if (!current) {
+          return [created];
+        }
+        return sortPrompts([...current, created]);
+      });
+    },
+  });
+};
+
+export const useUpdatePrompt = () => {
+  const queryClient = useQueryClient();
+  return useMutation<Prompt, HttpError, { id: number; title: string; content: string }>({
+    mutationFn: ({ id, title, content }) => updatePrompt(id, { title, content }),
+    onSuccess: (updated) => {
+      queryClient.setQueryData<PromptList | undefined>(PROMPTS_QUERY_KEY, (current) => {
+        if (!current) {
+          return current;
+        }
+        const next = current.map((item) => (item.id === updated.id ? updated : item));
+        return sortPrompts(next);
+      });
+    },
+  });
+};
+
+export const useDeletePrompt = () => {
+  const queryClient = useQueryClient();
+  return useMutation<{ message?: string }, HttpError, number>({
+    mutationFn: (id) => deletePrompt(id),
+    onSuccess: (_result, id) => {
+      queryClient.setQueryData<PromptList | undefined>(PROMPTS_QUERY_KEY, (current) => {
+        if (!current) {
+          return current;
+        }
+        return current.filter((item) => item.id !== id);
+      });
+    },
+  });
+};
+
+type ReorderContext = {
+  previous?: PromptList;
+};
+
+export const useReorderPrompts = () => {
+  const queryClient = useQueryClient();
+  return useMutation<unknown, HttpError, PromptList, ReorderContext>({
+    mutationFn: async (nextOrder) => {
+      const items = nextOrder.map((prompt) => ({ id: prompt.id, position: prompt.position }));
+      await reorderPrompts({ items });
+    },
+    onMutate: async (nextOrder) => {
+      await queryClient.cancelQueries({ queryKey: PROMPTS_QUERY_KEY });
+      const previous = queryClient.getQueryData<PromptList>(PROMPTS_QUERY_KEY);
+      queryClient.setQueryData(PROMPTS_QUERY_KEY, nextOrder);
+      return { previous };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(PROMPTS_QUERY_KEY, context.previous);
+      }
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: PROMPTS_QUERY_KEY });
+    },
+  });
+};

--- a/frontend/src/features/prompts/types/prompt.ts
+++ b/frontend/src/features/prompts/types/prompt.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const promptSchema = z.object({
+  id: z.number().int().positive(),
+  title: z.string(),
+  content: z.string(),
+  position: z.number().int().nonnegative(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export type Prompt = z.infer<typeof promptSchema>;
+
+export const promptListSchema = z.array(promptSchema);
+
+export type PromptList = z.infer<typeof promptListSchema>;
+
+export const promptReorderItemSchema = z.object({
+  id: z.number().int().positive(),
+  position: z.number().int().nonnegative(),
+});
+
+export type PromptReorderItem = z.infer<typeof promptReorderItemSchema>;

--- a/frontend/src/pages/prompts/PromptsPage.test.tsx
+++ b/frontend/src/pages/prompts/PromptsPage.test.tsx
@@ -1,0 +1,278 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { I18nextProvider } from 'react-i18next';
+import { vi } from 'vitest';
+import type { Mock } from 'vitest';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+import PromptsPage from './PromptsPage';
+import i18n from '@/config/i18n';
+import {
+  useCreatePrompt,
+  useDeletePrompt,
+  usePromptList,
+  useReorderPrompts,
+  useUpdatePrompt,
+} from '@/features/prompts/hooks/usePrompts';
+import type { Prompt } from '@/features/prompts/types/prompt';
+import { HttpError } from '@/lib/api/http';
+
+vi.mock('@/features/prompts/hooks/usePrompts', () => ({
+  usePromptList: vi.fn(),
+  useCreatePrompt: vi.fn(),
+  useUpdatePrompt: vi.fn(),
+  useDeletePrompt: vi.fn(),
+  useReorderPrompts: vi.fn(),
+}));
+
+vi.mock('@sentry/react', () => ({
+  addBreadcrumb: vi.fn(),
+  captureException: vi.fn(),
+}));
+
+const mockedUsePromptList = vi.mocked(usePromptList);
+const mockedUseCreatePrompt = vi.mocked(useCreatePrompt);
+const mockedUseUpdatePrompt = vi.mocked(useUpdatePrompt);
+const mockedUseDeletePrompt = vi.mocked(useDeletePrompt);
+const mockedUseReorderPrompts = vi.mocked(useReorderPrompts);
+
+type MutationOverrides<TData, TVariables> = Partial<
+  Omit<UseMutationResult<TData, HttpError, TVariables>, 'mutate'>
+>;
+
+type MutationMock<TVariables> = Mock<
+  (variables: TVariables, options?: Parameters<UseMutationResult<unknown, HttpError, TVariables>['mutate']>[1]) => void
+>;
+
+const buildPrompt = (override: Partial<Prompt> = {}): Prompt => ({
+  id: override.id ?? 1,
+  title: override.title ?? 'Sample prompt',
+  content: override.content ?? 'Provide a summary of the latest company news.',
+  position: override.position ?? 1,
+  createdAt: override.createdAt ?? '2024-01-01T00:00:00.000Z',
+  updatedAt: override.updatedAt ?? '2024-01-01T00:00:00.000Z',
+});
+
+const createQueryResult = (
+  data: Prompt[],
+  overrides: Partial<UseQueryResult<Prompt[], HttpError>> = {},
+): UseQueryResult<Prompt[], HttpError> => {
+  const refetch = vi.fn();
+  const remove = vi.fn();
+  const base: UseQueryResult<Prompt[], HttpError> = {
+    data,
+    dataUpdatedAt: Date.now(),
+    error: null,
+    errorUpdatedAt: 0,
+    errorUpdateCount: 0,
+    failureCount: 0,
+    failureReason: null,
+    failureReasonUpdatedAt: 0,
+    fetchStatus: 'idle',
+    isError: false,
+    isFetched: true,
+    isFetchedAfterMount: true,
+    isFetching: false,
+    isInitialLoading: false,
+    isLoading: false,
+    isLoadingError: false,
+    isPaused: false,
+    isPending: false,
+    isRefetchError: false,
+    isRefetching: false,
+    isSuccess: true,
+    refetch,
+    remove,
+    status: 'success',
+  };
+
+  return { ...base, ...overrides };
+};
+
+const createMutationResult = <TData, TVariables>(
+  mutateMock: MutationMock<TVariables>,
+  overrides: MutationOverrides<TData, TVariables> = {},
+): UseMutationResult<TData, HttpError, TVariables> => {
+  const mutate: UseMutationResult<TData, HttpError, TVariables>['mutate'] = (variables, options) => {
+    mutateMock(variables, options);
+  };
+
+  return {
+    context: undefined,
+    data: undefined,
+    error: null,
+    failureCount: 0,
+    failureReason: null,
+    isError: false,
+    isIdle: true,
+    isPending: false,
+    isPaused: false,
+    isSuccess: false,
+    mutate,
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+    status: 'idle',
+    submittedAt: 0,
+    variables: undefined,
+    ...overrides,
+  };
+};
+
+const renderPage = () => {
+  return render(
+    <I18nextProvider i18n={i18n}>
+      <PromptsPage />
+    </I18nextProvider>,
+  );
+};
+
+describe('PromptsPage', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await i18n.changeLanguage('en');
+  });
+
+  it('renders the prompt list with preview', () => {
+    const prompts = [
+      buildPrompt({ id: 1, title: 'Welcome message', content: 'Draft a welcome message for new followers.', position: 1 }),
+      buildPrompt({
+        id: 2,
+        title: 'Launch announcement',
+        content:
+          'Write an enthusiastic LinkedIn post announcing our new product launch with key benefits and a call to action for demo requests.',
+        position: 2,
+      }),
+    ];
+
+    mockedUsePromptList.mockReturnValue(createQueryResult(prompts));
+    mockedUseCreatePrompt.mockReturnValue(createMutationResult(vi.fn()));
+    mockedUseUpdatePrompt.mockReturnValue(createMutationResult(vi.fn()));
+    mockedUseDeletePrompt.mockReturnValue(createMutationResult(vi.fn()));
+    mockedUseReorderPrompts.mockReturnValue(createMutationResult(vi.fn()));
+
+    renderPage();
+
+    expect(screen.getByRole('heading', { level: 1, name: /prompts/i })).toBeInTheDocument();
+    expect(screen.getByText('Welcome message')).toBeInTheDocument();
+    expect(screen.getByText(/Write an enthusiastic LinkedIn post/i)).toBeInTheDocument();
+  });
+
+  it('creates a new prompt successfully', async () => {
+    const user = userEvent.setup();
+    const mutateMock = vi.fn((variables: { title: string; content: string }, options?: { onSuccess?: (prompt: Prompt) => void }) => {
+      options?.onSuccess?.(buildPrompt({ id: 3, title: variables.title, content: variables.content }));
+    });
+
+    mockedUsePromptList.mockReturnValue(createQueryResult([]));
+    mockedUseCreatePrompt.mockReturnValue(createMutationResult(mutateMock));
+    mockedUseUpdatePrompt.mockReturnValue(createMutationResult(vi.fn()));
+    mockedUseDeletePrompt.mockReturnValue(createMutationResult(vi.fn()));
+    mockedUseReorderPrompts.mockReturnValue(createMutationResult(vi.fn()));
+
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: /new prompt/i }));
+    await user.type(screen.getByLabelText('Title'), 'Growth update');
+    await user.type(screen.getByLabelText('Content'), 'Share quarterly growth metrics and key learnings.');
+    await user.click(screen.getByRole('button', { name: /save prompt/i }));
+
+    expect(mutateMock).toHaveBeenCalledWith(
+      { title: 'Growth update', content: 'Share quarterly growth metrics and key learnings.' },
+      expect.any(Object),
+    );
+
+    expect(await screen.findByText('Prompt created successfully.')).toBeInTheDocument();
+  });
+
+  it('validates required title before submitting', async () => {
+    const user = userEvent.setup();
+    const mutateMock = vi.fn();
+
+    mockedUsePromptList.mockReturnValue(createQueryResult([]));
+    mockedUseCreatePrompt.mockReturnValue(createMutationResult(mutateMock));
+    mockedUseUpdatePrompt.mockReturnValue(createMutationResult(vi.fn()));
+    mockedUseDeletePrompt.mockReturnValue(createMutationResult(vi.fn()));
+    mockedUseReorderPrompts.mockReturnValue(createMutationResult(vi.fn()));
+
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: /new prompt/i }));
+    await user.type(screen.getByLabelText('Content'), 'Explain the new onboarding flow.');
+    await user.click(screen.getByRole('button', { name: /save prompt/i }));
+
+    expect(screen.getByText('Enter a title.')).toBeInTheDocument();
+    expect(mutateMock).not.toHaveBeenCalled();
+  });
+
+  it('deletes a prompt after confirmation', async () => {
+    const user = userEvent.setup();
+    const mutateMock = vi.fn();
+    const prompts = [buildPrompt({ id: 5, title: 'Weekly digest', position: 1 })];
+
+    mockedUsePromptList.mockReturnValue(createQueryResult(prompts));
+    mockedUseCreatePrompt.mockReturnValue(createMutationResult(vi.fn()));
+    mockedUseUpdatePrompt.mockReturnValue(createMutationResult(vi.fn()));
+    mockedUseDeletePrompt.mockReturnValue(createMutationResult(mutateMock));
+    mockedUseReorderPrompts.mockReturnValue(createMutationResult(vi.fn()));
+
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: /delete/i }));
+
+    expect(confirmSpy).toHaveBeenCalledWith('Are you sure you want to delete this prompt?');
+    expect(mutateMock).toHaveBeenCalledWith(5, expect.any(Object));
+
+    confirmSpy.mockRestore();
+  });
+
+  it('reorders prompts when dragged', () => {
+    const mutateMock = vi.fn();
+    const prompts = [
+      buildPrompt({ id: 1, title: 'First prompt', position: 1 }),
+      buildPrompt({ id: 2, title: 'Second prompt', position: 2 }),
+    ];
+
+    mockedUsePromptList.mockReturnValue(createQueryResult(prompts));
+    mockedUseCreatePrompt.mockReturnValue(createMutationResult(vi.fn()));
+    mockedUseUpdatePrompt.mockReturnValue(createMutationResult(vi.fn()));
+    mockedUseDeletePrompt.mockReturnValue(createMutationResult(vi.fn()));
+    mockedUseReorderPrompts.mockReturnValue(createMutationResult(mutateMock));
+
+    renderPage();
+
+    const items = screen.getAllByRole('listitem');
+    const dragData: { [key: string]: string } = {};
+    const eventData = {
+      dataTransfer: {
+        setData: (type: string, value: string) => {
+          dragData[type] = value;
+        },
+        getData: (type: string) => dragData[type] ?? '',
+        dropEffect: '',
+        effectAllowed: '',
+      },
+    } as unknown as DragEventInit;
+
+    fireEvent.dragStart(items[1], eventData);
+    fireEvent.dragOver(items[0], eventData);
+    fireEvent.drop(items[0], eventData);
+
+    expect(mutateMock).toHaveBeenCalled();
+    const firstCall = mutateMock.mock.calls[0];
+    expect(firstCall).toBeDefined();
+
+    const variables = firstCall?.[0];
+    expect(Array.isArray(variables)).toBe(true);
+
+    if (!Array.isArray(variables)) {
+      return;
+    }
+
+    expect(variables).toEqual([
+      expect.objectContaining({ id: 2, position: 1 }),
+      expect.objectContaining({ id: 1, position: 2 }),
+    ]);
+  });
+});

--- a/frontend/src/pages/prompts/PromptsPage.tsx
+++ b/frontend/src/pages/prompts/PromptsPage.tsx
@@ -1,0 +1,643 @@
+import type { DragEvent, FormEvent } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import * as Sentry from '@sentry/react';
+
+import { EmptyState } from '@/components/feedback/EmptyState';
+import { ErrorState } from '@/components/feedback/ErrorState';
+import { LoadingSkeleton } from '@/components/feedback/LoadingSkeleton';
+import {
+  useCreatePrompt,
+  useDeletePrompt,
+  usePromptList,
+  useReorderPrompts,
+  useUpdatePrompt,
+} from '@/features/prompts/hooks/usePrompts';
+import type { Prompt } from '@/features/prompts/types/prompt';
+import { HttpError } from '@/lib/api/http';
+import { clsx } from 'clsx';
+
+const TITLE_LIMIT = 120;
+const CONTENT_PREVIEW_LIMIT = 100;
+
+type FormMode = 'create' | 'edit';
+
+type FormErrors = {
+  title?: string;
+  content?: string;
+};
+
+type Feedback = {
+  type: 'success' | 'error';
+  message: string;
+};
+
+const truncateContent = (content: string) => {
+  const normalized = content.trim();
+
+  if (normalized.length <= CONTENT_PREVIEW_LIMIT) {
+    return normalized || '…';
+  }
+
+  return `${normalized.slice(0, CONTENT_PREVIEW_LIMIT).trimEnd()}…`;
+};
+
+const resolveErrorMessage = (error: unknown, fallback: string) => {
+  if (error instanceof HttpError) {
+    return error.message;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return fallback;
+};
+
+const shouldReportError = (error: unknown) => {
+  return !(error instanceof HttpError && error.status === 401);
+};
+
+const normalizeOrder = (items: Prompt[]): Prompt[] => {
+  return items.map((item, index) => ({ ...item, position: index + 1 }));
+};
+
+const PromptsPage = () => {
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    document.title = t('prompts.meta.title', 'lkdposts - Prompts');
+    Sentry.addBreadcrumb({
+      category: 'prompts',
+      message: 'prompts:view_opened',
+      level: 'info',
+    });
+  }, [t]);
+
+  const promptList = usePromptList();
+  const createPrompt = useCreatePrompt();
+  const updatePrompt = useUpdatePrompt();
+  const deletePrompt = useDeletePrompt();
+  const reorderPrompts = useReorderPrompts();
+
+  const prompts = promptList.data ?? [];
+  const isLoading = promptList.isLoading && !promptList.isFetched;
+  const isError = promptList.isError;
+
+  const [formMode, setFormMode] = useState<FormMode | null>(null);
+  const [editingPrompt, setEditingPrompt] = useState<Prompt | null>(null);
+  const [titleInput, setTitleInput] = useState('');
+  const [contentInput, setContentInput] = useState('');
+  const [formErrors, setFormErrors] = useState<FormErrors>({});
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
+  const [draggingId, setDraggingId] = useState<number | null>(null);
+  const [pendingScrollId, setPendingScrollId] = useState<number | null>(null);
+
+  const itemRefs = useRef<Map<number, HTMLDivElement>>(new Map());
+  const lastFetchErrorRef = useRef<unknown>(null);
+
+  useEffect(() => {
+    if (!promptList.error || !shouldReportError(promptList.error)) {
+      lastFetchErrorRef.current = promptList.error ?? null;
+      return;
+    }
+
+    if (lastFetchErrorRef.current === promptList.error) {
+      return;
+    }
+
+    lastFetchErrorRef.current = promptList.error;
+    Sentry.captureException(promptList.error, {
+      tags: { feature: 'prompts', action: 'fetch' },
+    });
+  }, [promptList.error]);
+
+  useEffect(() => {
+    if (pendingScrollId === null) {
+      return;
+    }
+
+    const element = itemRefs.current.get(pendingScrollId);
+    if (element) {
+      element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      element.focus({ preventScroll: true });
+      setPendingScrollId(null);
+    }
+  }, [pendingScrollId, promptList.data]);
+
+  const resetForm = () => {
+    setFormMode(null);
+    setEditingPrompt(null);
+    setTitleInput('');
+    setContentInput('');
+    setFormErrors({});
+  };
+
+  const handleOpenCreateForm = () => {
+    setFeedback(null);
+    setFormMode('create');
+    setEditingPrompt(null);
+    setTitleInput('');
+    setContentInput('');
+    setFormErrors({});
+  };
+
+  const handleOpenEditForm = (prompt: Prompt) => {
+    setFeedback(null);
+    setFormMode('edit');
+    setEditingPrompt(prompt);
+    setTitleInput(prompt.title);
+    setContentInput(prompt.content);
+    setFormErrors({});
+  };
+
+  const handleCancelForm = () => {
+    resetForm();
+  };
+
+  const registerItemRef = (id: number) => (element: HTMLDivElement | null) => {
+    if (!element) {
+      itemRefs.current.delete(id);
+      return;
+    }
+
+    itemRefs.current.set(id, element);
+  };
+
+  const validateForm = (): { errors: FormErrors; title: string; content: string } => {
+    const errors: FormErrors = {};
+    const trimmedTitle = titleInput.trim();
+    const trimmedContent = contentInput.trim();
+
+    if (!trimmedTitle) {
+      errors.title = t('prompts.form.errors.titleRequired', 'Enter a title.');
+    } else if (trimmedTitle.length > TITLE_LIMIT) {
+      errors.title = t('prompts.form.errors.titleMax', 'Title must be 120 characters or fewer.');
+    }
+
+    if (!trimmedContent) {
+      errors.content = t('prompts.form.errors.contentRequired', 'Enter the prompt content.');
+    }
+
+    setFormErrors(errors);
+
+    return { errors, title: trimmedTitle, content: trimmedContent };
+  };
+
+  const reportError = (action: 'create' | 'update' | 'delete' | 'reorder', error: unknown, extra: Record<string, unknown>) => {
+    if (!shouldReportError(error)) {
+      return;
+    }
+
+    const capturedError = error instanceof Error ? error : new Error('Prompts operation failed');
+
+    Sentry.captureException(capturedError, {
+      tags: { feature: 'prompts', action },
+      extra,
+    });
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!formMode) {
+      return;
+    }
+
+    const { errors, title, content } = validateForm();
+    if (Object.keys(errors).length > 0) {
+      return;
+    }
+
+    setFeedback(null);
+
+    if (formMode === 'create') {
+      createPrompt.mutate(
+        { title, content },
+        {
+          onSuccess: (created) => {
+            setFeedback({
+              type: 'success',
+              message: t('prompts.feedback.created', 'Prompt created successfully.'),
+            });
+            setPendingScrollId(created.id);
+            resetForm();
+          },
+          onError: (error) => {
+            setFeedback({
+              type: 'error',
+              message: resolveErrorMessage(
+                error,
+                t('prompts.feedback.error', 'The operation failed. Try again.'),
+              ),
+            });
+            reportError('create', error, {
+              titleLength: title.length,
+              contentLength: content.length,
+            });
+          },
+        },
+      );
+      return;
+    }
+
+    if (!editingPrompt) {
+      return;
+    }
+
+    updatePrompt.mutate(
+      { id: editingPrompt.id, title, content },
+      {
+        onSuccess: (updated) => {
+          setFeedback({
+            type: 'success',
+            message: t('prompts.feedback.updated', 'Prompt updated successfully.'),
+          });
+          setPendingScrollId(updated.id);
+          resetForm();
+        },
+        onError: (error) => {
+          setFeedback({
+            type: 'error',
+            message: resolveErrorMessage(
+              error,
+              t('prompts.feedback.error', 'The operation failed. Try again.'),
+            ),
+          });
+          reportError('update', error, {
+            promptId: editingPrompt.id,
+            titleLength: title.length,
+            contentLength: content.length,
+          });
+        },
+      },
+    );
+  };
+
+  const handleDeletePrompt = (prompt: Prompt) => {
+    const confirmed = window.confirm(
+      t('prompts.delete.confirm', 'Are you sure you want to delete this prompt?'),
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    setFeedback(null);
+
+    deletePrompt.mutate(prompt.id, {
+      onSuccess: () => {
+        setFeedback({
+          type: 'success',
+          message: t('prompts.feedback.deleted', 'Prompt deleted successfully.'),
+        });
+        if (editingPrompt?.id === prompt.id) {
+          resetForm();
+        }
+      },
+      onError: (error) => {
+        setFeedback({
+          type: 'error',
+          message: resolveErrorMessage(
+            error,
+            t('prompts.feedback.error', 'The operation failed. Try again.'),
+          ),
+        });
+        reportError('delete', error, { promptId: prompt.id });
+      },
+    });
+  };
+
+  const reorderById = (sourceId: number, targetId: number | null) => {
+    if (reorderPrompts.isPending) {
+      return;
+    }
+
+    if (targetId !== null && targetId === sourceId) {
+      return;
+    }
+
+    const items = prompts;
+    const sourceIndex = items.findIndex((item) => item.id === sourceId);
+
+    if (sourceIndex === -1) {
+      return;
+    }
+
+    const next = [...items];
+    const [moved] = next.splice(sourceIndex, 1);
+
+    let insertIndex = targetId === null ? next.length : next.findIndex((item) => item.id === targetId);
+
+    if (insertIndex < 0) {
+      insertIndex = next.length;
+    }
+
+    next.splice(insertIndex, 0, moved);
+
+    const normalized = normalizeOrder(next);
+
+    setFeedback(null);
+    reorderPrompts.mutate(normalized, {
+      onSuccess: () => {
+        setFeedback({
+          type: 'success',
+          message: t('prompts.feedback.reordered', 'Prompt order updated.'),
+        });
+      },
+      onError: (error) => {
+        setFeedback({
+          type: 'error',
+          message: resolveErrorMessage(
+            error,
+            t('prompts.reorder.error', 'We could not reorder the prompts. Try again.'),
+          ),
+        });
+        reportError('reorder', error, { promptIds: normalized.map((item) => item.id) });
+      },
+    });
+  };
+
+  const handleDragStart = (event: DragEvent<HTMLDivElement>, promptId: number) => {
+    setDraggingId(promptId);
+    event.dataTransfer.effectAllowed = 'move';
+    event.dataTransfer.setData('text/plain', String(promptId));
+  };
+
+  const resolveSourceId = (event: DragEvent<HTMLDivElement>) => {
+    if (draggingId !== null) {
+      return draggingId;
+    }
+
+    const data = event.dataTransfer.getData('text/plain');
+    const parsed = Number.parseInt(data, 10);
+    return Number.isNaN(parsed) ? null : parsed;
+  };
+
+  const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+  };
+
+  const handleDropOnItem = (event: DragEvent<HTMLDivElement>, targetId: number) => {
+    event.preventDefault();
+    const sourceId = resolveSourceId(event);
+    if (!sourceId || sourceId === targetId) {
+      setDraggingId(null);
+      return;
+    }
+
+    reorderById(sourceId, targetId);
+    setDraggingId(null);
+  };
+
+  const handleDropOnList = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    const sourceId = resolveSourceId(event);
+    if (!sourceId) {
+      setDraggingId(null);
+      return;
+    }
+
+    reorderById(sourceId, null);
+    setDraggingId(null);
+  };
+
+  const handleDragEnd = () => {
+    setDraggingId(null);
+  };
+
+  const isSaving = createPrompt.isPending || updatePrompt.isPending;
+  const isDeleting = deletePrompt.isPending;
+  const deletingId = deletePrompt.variables ?? null;
+  const isFormOpen = formMode !== null;
+
+  const loadingSkeletons = useMemo(() => Array.from({ length: 3 }), []);
+
+  return (
+    <section className="space-y-6" aria-labelledby="prompts-heading">
+      <header className="space-y-2">
+        <h1 id="prompts-heading" className="text-2xl font-semibold text-foreground">
+          {t('prompts.heading', 'Prompts')}
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          {t('prompts.subtitle', 'Manage the prompts used to generate your content.')}
+        </p>
+      </header>
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <button
+          type="button"
+          onClick={handleOpenCreateForm}
+          className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={isSaving}
+        >
+          {t('prompts.actions.new', 'New prompt')}
+        </button>
+        {reorderPrompts.isPending ? (
+          <span className="text-xs text-muted-foreground">
+            {t('prompts.reorder.pending', 'Updating order...')}
+          </span>
+        ) : null}
+      </div>
+
+      {feedback ? (
+        <div
+          role={feedback.type === 'error' ? 'alert' : 'status'}
+          className={clsx(
+            'rounded-md border px-4 py-3 text-sm',
+            feedback.type === 'success'
+              ? 'border-primary/30 bg-primary/10 text-primary'
+              : 'border-danger/30 bg-danger/10 text-danger',
+          )}
+        >
+          {feedback.message}
+        </div>
+      ) : null}
+
+      {isFormOpen ? (
+        <form onSubmit={handleSubmit} className="card space-y-4 p-6" noValidate>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h2 className="text-lg font-semibold text-foreground">
+              {formMode === 'create'
+                ? t('prompts.form.createTitle', 'Create prompt')
+                : t('prompts.form.editTitle', 'Edit prompt')}
+            </h2>
+            <button
+              type="button"
+              onClick={handleCancelForm}
+              className="inline-flex items-center justify-center rounded-md border border-border px-3 py-1.5 text-sm font-medium text-foreground transition hover:bg-muted"
+            >
+              {t('prompts.actions.cancel', 'Cancel')}
+            </button>
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor="prompt-title" className="text-sm font-medium text-foreground">
+              {t('prompts.form.titleLabel', 'Title')}
+            </label>
+            <input
+              id="prompt-title"
+              name="title"
+              value={titleInput}
+              onChange={(event) => setTitleInput(event.target.value)}
+              maxLength={TITLE_LIMIT}
+              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground shadow-sm focus:border-primary focus:ring-2 focus:ring-primary/40"
+              required
+            />
+            {formErrors.title ? (
+              <p className="text-sm text-danger" role="alert">
+                {formErrors.title}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor="prompt-content" className="text-sm font-medium text-foreground">
+              {t('prompts.form.contentLabel', 'Content')}
+            </label>
+            <textarea
+              id="prompt-content"
+              name="content"
+              value={contentInput}
+              onChange={(event) => setContentInput(event.target.value)}
+              className="min-h-32 w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground shadow-sm focus:border-primary focus:ring-2 focus:ring-primary/40"
+              required
+            />
+            {formErrors.content ? (
+              <p className="text-sm text-danger" role="alert">
+                {formErrors.content}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="flex items-center justify-end gap-2">
+            <button
+              type="submit"
+              className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={isSaving}
+            >
+              {isSaving
+                ? t('prompts.form.saving', 'Saving...')
+                : t('prompts.form.save', 'Save prompt')}
+            </button>
+          </div>
+        </form>
+      ) : null}
+
+      {isLoading ? (
+        <div className="space-y-3" role="status" aria-live="polite">
+          {loadingSkeletons.map((_, index) => (
+            <div key={index} className="card space-y-3 p-4">
+              <LoadingSkeleton className="h-5 w-3/4" />
+              <LoadingSkeleton className="h-4 w-full" />
+              <LoadingSkeleton className="h-4 w-2/3" />
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {!isLoading && isError ? (
+        <ErrorState
+          title={t('prompts.list.error', 'We could not load the prompts. Try again.')}
+          action={
+            <button
+              type="button"
+              onClick={() => {
+                setFeedback(null);
+                Promise.resolve(promptList.refetch()).catch(() => {
+                  // the query already exposes the error state
+                });
+              }}
+              className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90"
+            >
+              {t('prompts.actions.retry', 'Try again')}
+            </button>
+          }
+        />
+      ) : null}
+
+      {!isLoading && !isError && prompts.length === 0 ? (
+        <EmptyState
+          title={t('prompts.empty.title', 'No prompt registered yet.')}
+          description={t('prompts.empty.description', 'Create your first prompt to get started.')}
+          action={
+            <button
+              type="button"
+              onClick={handleOpenCreateForm}
+              className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90"
+            >
+              {t('prompts.actions.createFirst', 'Create prompt')}
+            </button>
+          }
+        />
+      ) : null}
+
+      {!isLoading && !isError && prompts.length > 0 ? (
+        <div className="space-y-2">
+          <p className="text-xs text-muted-foreground">
+            {t('prompts.list.reorderHint', 'Drag the handle or card to change the order.')}
+          </p>
+          <div
+            onDragOver={handleDragOver}
+            onDrop={handleDropOnList}
+            className="space-y-3"
+            role="list"
+          >
+            {prompts.map((prompt) => (
+              <div
+                key={prompt.id}
+                role="listitem"
+                className={clsx(
+                  'card flex flex-col gap-3 p-4 outline-none transition-shadow focus-visible:ring-2 focus-visible:ring-primary',
+                  draggingId === prompt.id ? 'opacity-60 ring-2 ring-primary/40' : '',
+                )}
+                draggable
+                onDragStart={(event) => handleDragStart(event, prompt.id)}
+                onDragOver={handleDragOver}
+                onDrop={(event) => handleDropOnItem(event, prompt.id)}
+                onDragEnd={handleDragEnd}
+                tabIndex={0}
+                ref={registerItemRef(prompt.id)}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex flex-1 flex-col gap-1">
+                    <h3 className="text-base font-semibold text-foreground">{prompt.title}</h3>
+                    <p className="text-sm text-muted-foreground">{truncateContent(prompt.content)}</p>
+                  </div>
+                  <div className="flex items-start gap-2">
+                    <button
+                      type="button"
+                      onClick={() => handleOpenEditForm(prompt)}
+                      className="inline-flex items-center justify-center rounded-md border border-border px-3 py-1.5 text-xs font-medium text-foreground transition hover:bg-muted"
+                    >
+                      {t('prompts.actions.edit', 'Edit')}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDeletePrompt(prompt)}
+                      className="inline-flex items-center justify-center rounded-md border border-danger/40 px-3 py-1.5 text-xs font-medium text-danger transition hover:bg-danger/10"
+                      disabled={isDeleting}
+                    >
+                      {isDeleting && deletingId === prompt.id
+                        ? t('prompts.actions.deleting', 'Deleting...')
+                        : t('prompts.actions.delete', 'Delete')}
+                    </button>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <span aria-hidden="true">⋮⋮</span>
+                  <span className="sr-only">
+                    {t('prompts.list.dragLabel', 'Drag to reposition this prompt.')}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+};
+
+export default PromptsPage;


### PR DESCRIPTION
## Summary
- add a secured /prompts route with navigation entry
- implement prompt CRUD UI with drag-and-drop reordering and Sentry-aware error handling
- provide React Query helpers, API bindings, translations and Vitest coverage for prompt workflows

## Testing
- npm run test -- PromptsPage.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d5bcad30c483258a46874903e7a96d