### PR TITLE
Enhance prompts list usability and duplication

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
             "dependencies": {
                 "@sentry/react": "^8.38.0",
                 "@tanstack/react-query": "^5.59.3",
+                "@tanstack/react-virtual": "^3.13.12",
                 "axios": "^1.7.9",
                 "clsx": "^2.1.1",
                 "i18next": "^25.4.1",
@@ -1415,6 +1416,33 @@
             },
             "peerDependencies": {
                 "react": "^18 || ^19"
+            }
+        },
+        "node_modules/@tanstack/react-virtual": {
+            "version": "3.13.12",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz",
+            "integrity": "sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==",
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/virtual-core": "3.13.12"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@tanstack/virtual-core": {
+            "version": "3.13.12",
+            "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz",
+            "integrity": "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
             }
         },
         "node_modules/@testing-library/dom": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "dependencies": {
         "@sentry/react": "^8.38.0",
         "@tanstack/react-query": "^5.59.3",
+        "@tanstack/react-virtual": "^3.13.12",
         "axios": "^1.7.9",
         "clsx": "^2.1.1",
         "i18next": "^25.4.1",

--- a/frontend/src/features/prompts/api/prompts.ts
+++ b/frontend/src/features/prompts/api/prompts.ts
@@ -6,6 +6,7 @@ export const PROMPTS_QUERY_KEY = ['prompts'] as const;
 type CreatePromptPayload = {
   title: string;
   content: string;
+  position?: number;
 };
 
 type UpdatePromptPayload = {

--- a/frontend/src/features/prompts/hooks/usePrompts.ts
+++ b/frontend/src/features/prompts/hooks/usePrompts.ts
@@ -30,8 +30,8 @@ export const usePromptList = () => {
 
 export const useCreatePrompt = () => {
   const queryClient = useQueryClient();
-  return useMutation<Prompt, HttpError, { title: string; content: string }>({
-    mutationFn: ({ title, content }) => createPrompt({ title, content }),
+  return useMutation<Prompt, HttpError, { title: string; content: string; position?: number }>({
+    mutationFn: ({ title, content, position }) => createPrompt({ title, content, position }),
     onSuccess: (created) => {
       queryClient.setQueryData<PromptList | undefined>(PROMPTS_QUERY_KEY, (current) => {
         if (!current) {

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -143,4 +143,11 @@
   .text-balance {
     text-wrap: balance;
   }
+
+  .line-clamp-3 {
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
 }


### PR DESCRIPTION
## Summary
- add prompt duplication workflow that appends "(cópia)", queues the new item last, and displays success feedback
- trim the list UI with inline expand/collapse controls, textarea auto-grow controls, and virtualization when many prompts are present
- expand tests to cover duplication, expand/collapse, and drag reordering after duplication

## Testing
- npx eslint src/features/prompts/api/prompts.ts src/features/prompts/hooks/usePrompts.ts src/pages/prompts/PromptsPage.tsx src/pages/prompts/PromptsPage.test.tsx
- npx vitest run src/pages/prompts/PromptsPage.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d5c1a18fb88325b2a9fb7d1ce806aa