### PR TITLE
Fix prompt list parsing for new API response

### DIFF
--- a/frontend/src/features/prompts/api/prompts.ts
+++ b/frontend/src/features/prompts/api/prompts.ts
@@ -1,5 +1,11 @@
 import { deleteJson, getJson, patchJson, postJson, putJson } from '@/lib/api/http';
-import { promptListSchema, promptSchema, type Prompt, type PromptList, type PromptReorderItem } from '../types/prompt';
+import {
+  promptListResponseSchema,
+  promptSchema,
+  type Prompt,
+  type PromptReorderItem,
+  type PromptListResponse,
+} from '../types/prompt';
 
 export const PROMPTS_QUERY_KEY = ['prompts'] as const;
 
@@ -20,8 +26,13 @@ type ReorderPayload = {
   items: PromptReorderItem[];
 };
 
-export const fetchPrompts = () => {
-  return getJson<PromptList>('/api/v1/prompts', promptListSchema);
+export const fetchPrompts = async () => {
+  const response = await getJson<PromptListResponse>(
+    '/api/v1/prompts',
+    promptListResponseSchema,
+  );
+
+  return response.items;
 };
 
 export const createPrompt = (payload: CreatePromptPayload) => {

--- a/frontend/src/features/prompts/types/prompt.ts
+++ b/frontend/src/features/prompts/types/prompt.ts
@@ -16,6 +16,12 @@ export const promptListSchema = z.array(promptSchema);
 
 export type PromptList = z.infer<typeof promptListSchema>;
 
+export const promptListResponseSchema = z.object({
+  items: promptListSchema,
+});
+
+export type PromptListResponse = z.infer<typeof promptListResponseSchema>;
+
 export const promptReorderItemSchema = z.object({
   id: z.string().min(1),
   position: z.number().int().nonnegative(),


### PR DESCRIPTION
## Summary
- add a schema for the prompt list response object
- parse the new `{ items: [...] }` payload when fetching prompts so the UI receives the saved prompts

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68d6c350314c8325832e2bb1705fbad0