### PR TITLE
Improve prompt reordering experience and app params form

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,9 @@
             "name": "frontend",
             "version": "0.0.1",
             "dependencies": {
+                "@dnd-kit/core": "^6.3.1",
+                "@dnd-kit/sortable": "^10.0.0",
+                "@dnd-kit/utilities": "^3.2.2",
                 "@sentry/react": "^8.38.0",
                 "@tanstack/react-query": "^5.59.3",
                 "@tanstack/react-virtual": "^3.13.12",
@@ -336,6 +339,59 @@
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@dnd-kit/accessibility": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+            "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0"
+            }
+        },
+        "node_modules/@dnd-kit/core": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+            "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@dnd-kit/accessibility": "^3.1.1",
+                "@dnd-kit/utilities": "^3.2.2",
+                "tslib": "^2.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0",
+                "react-dom": ">=16.8.0"
+            }
+        },
+        "node_modules/@dnd-kit/sortable": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+            "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+            "license": "MIT",
+            "dependencies": {
+                "@dnd-kit/utilities": "^3.2.2",
+                "tslib": "^2.0.0"
+            },
+            "peerDependencies": {
+                "@dnd-kit/core": "^6.3.0",
+                "react": ">=16.8.0"
+            }
+        },
+        "node_modules/@dnd-kit/utilities": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+            "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
@@ -6186,6 +6242,12 @@
             "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
             "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
             "dev": true
+        },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD"
         },
         "node_modules/type-check": {
             "version": "0.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,9 @@
         "lint:ci": "eslint \"src/**/*.{ts,tsx,js,jsx}\" -f json -o eslint-report.json"
     },
     "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@sentry/react": "^8.38.0",
         "@tanstack/react-query": "^5.59.3",
         "@tanstack/react-virtual": "^3.13.12",

--- a/frontend/src/config/i18n.ts
+++ b/frontend/src/config/i18n.ts
@@ -89,6 +89,10 @@ const resources = {
           error: 'We could not load the prompts. Try again.',
           reorderHint: 'Drag the handle or card to change the order.',
           dragLabel: 'Drag to reposition this prompt.',
+          moveUp: 'Move prompt up',
+          moveDown: 'Move prompt down',
+          dropZone: 'Drop here to move the prompt to the end.',
+          reorderDisabledWithFilters: 'Clear filters to reorder the full list before reordering.',
           ariaLabel: 'Saved prompts',
         },
         empty: {
@@ -536,6 +540,10 @@ const resources = {
           error: 'Nao foi possivel carregar os prompts. Tente novamente.',
           reorderHint: 'Arraste o card ou o manipulador para alterar a ordem.',
           dragLabel: 'Arraste para reposicionar este prompt.',
+          moveUp: 'Mover prompt para cima',
+          moveDown: 'Mover prompt para baixo',
+          dropZone: 'Solte aqui para mover o prompt para o final.',
+          reorderDisabledWithFilters: 'Limpe os filtros para reordenar toda a lista.',
           ariaLabel: 'Prompts salvos',
         },
         empty: {

--- a/frontend/src/pages/app-params/AppParamsPage.tsx
+++ b/frontend/src/pages/app-params/AppParamsPage.tsx
@@ -139,6 +139,17 @@ const AppParamsPage = () => {
   const openAiModelValue = useMemo<OpenAiModel | null>(() => {
     return isOpenAiModel(openAiModelInput) ? openAiModelInput : null;
   }, [openAiModelInput]);
+  const normalizedParams = useMemo(() => {
+    if (!params) {
+      return null;
+    }
+
+    return {
+      cooldown: params.posts_refresh_cooldown_seconds,
+      timeWindow: params.posts_time_window_days,
+      openAiModel: resolveOpenAiModelFromParams(params),
+    };
+  }, [params]);
 
   const cooldownError = useMemo(() => {
     if (cooldownValue === null) {
@@ -173,16 +184,16 @@ const AppParamsPage = () => {
   }, [openAiModelValue, t]);
 
   const isDirty = useMemo(() => {
-    if (!params || cooldownValue === null || timeWindowValue === null || !openAiModelValue) {
+    if (!normalizedParams || cooldownValue === null || timeWindowValue === null || !openAiModelValue) {
       return false;
     }
 
     return (
-      cooldownValue !== params.posts_refresh_cooldown_seconds ||
-      timeWindowValue !== params.posts_time_window_days ||
-      openAiModelValue !== params['openai.model']
+      cooldownValue !== normalizedParams.cooldown ||
+      timeWindowValue !== normalizedParams.timeWindow ||
+      openAiModelValue !== normalizedParams.openAiModel
     );
-  }, [cooldownValue, openAiModelValue, params, timeWindowValue]);
+  }, [cooldownValue, openAiModelValue, normalizedParams, timeWindowValue]);
 
   const canSave =
     hasData && !cooldownError && !timeWindowError && !openAiModelError && isDirty && !isSaving;
@@ -190,18 +201,18 @@ const AppParamsPage = () => {
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    if (!params || cooldownValue === null || timeWindowValue === null || !openAiModelValue || !isDirty) {
+    if (!params || !normalizedParams || cooldownValue === null || timeWindowValue === null || !openAiModelValue || !isDirty) {
       return;
     }
 
     const payload: AppParamsUpdateInput = {};
-    if (cooldownValue !== params.posts_refresh_cooldown_seconds) {
+    if (cooldownValue !== normalizedParams.cooldown) {
       payload.posts_refresh_cooldown_seconds = cooldownValue;
     }
-    if (timeWindowValue !== params.posts_time_window_days) {
+    if (timeWindowValue !== normalizedParams.timeWindow) {
       payload.posts_time_window_days = timeWindowValue;
     }
-    if (openAiModelValue !== params['openai.model']) {
+    if (openAiModelValue !== normalizedParams.openAiModel) {
       payload['openai.model'] = openAiModelValue;
     }
 


### PR DESCRIPTION
## Summary
- replace the prompts page drag-and-drop with dnd-kit sortable controls, keeping the ordered state in sync with selection/export logic and adding new localization strings
- update the prompts test suite to interact with the new move buttons and refreshed selection handling
- normalize the app parameters form dirty check so unchanged values keep the save action disabled

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6cd1fc27883258baa23eab078b3f9