### PR TITLE
Expose post preview payload for authenticated users

### DIFF
--- a/frontend/src/features/posts/types/post.ts
+++ b/frontend/src/features/posts/types/post.ts
@@ -21,9 +21,10 @@ export const postGenerationMetadataSchema = z
     tokensInput: z.number().int().nonnegative().nullable(),
     tokensOutput: z.number().int().nonnegative().nullable(),
     promptBaseHash: z.string().nullable(),
-    attemptCount: z.number().int().nonnegative(),
+    attemptCount: z.number().int().nonnegative().nullable(),
     updatedAt: z.string().nullable(),
   })
+  .partial()
   .nullable();
 
 export const postListItemSchema = z
@@ -33,7 +34,7 @@ export const postListItemSchema = z
     contentSnippet: z.string(),
     publishedAt: z.string(),
     feed: postFeedReferenceSchema,
-    post: postGenerationMetadataSchema,
+    post: postGenerationMetadataSchema.nullable().optional(),
   })
   .extend({
     link: z.string().nullable().optional(),


### PR DESCRIPTION
## Summary
- add a posts API endpoint that reuses the news preview controller and keep admin route coverage in tests
- allow regular authenticated users to fetch post request previews and add frontend fallback to legacy admin path
- expand e2e coverage to ensure both admin and posts preview routes behave as expected

## Testing
- `npm test -- admin.news.preview.e2e.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68d6e9f67780832581affeaa2234a7d3