### PR TITLE
Fix prompts page build issues

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@dnd-kit/core": "^6.3.1",
+                "@dnd-kit/modifiers": "^9.0.0",
                 "@dnd-kit/sortable": "^10.0.0",
                 "@dnd-kit/utilities": "^3.2.2",
                 "@sentry/react": "^8.38.0",
@@ -366,6 +367,20 @@
             "peerDependencies": {
                 "react": ">=16.8.0",
                 "react-dom": ">=16.8.0"
+            }
+        },
+        "node_modules/@dnd-kit/modifiers": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+            "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+            "license": "MIT",
+            "dependencies": {
+                "@dnd-kit/utilities": "^3.2.2",
+                "tslib": "^2.0.0"
+            },
+            "peerDependencies": {
+                "@dnd-kit/core": "^6.3.0",
+                "react": ">=16.8.0"
             }
         },
         "node_modules/@dnd-kit/sortable": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     },
     "dependencies": {
         "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@sentry/react": "^8.38.0",

--- a/frontend/src/pages/prompts/PromptsPage.tsx
+++ b/frontend/src/pages/prompts/PromptsPage.tsx
@@ -230,6 +230,7 @@ const PromptsPage = () => {
   const [activeId, setActiveId] = useState<string | null>(null);
   const [keyboardActiveId, setKeyboardActiveId] = useState<string | null>(null);
   const [liveAnnouncement, setLiveAnnouncement] = useState('');
+  const isSorting = activeId !== null;
   const sortedIdsRef = useRef(sortedIds);
   const reorderSessionRef = useRef<ReorderSession | null>(null);
   const pendingCommitTelemetryRef = useRef<ReorderCommitTelemetry | null>(null);
@@ -390,7 +391,6 @@ const PromptsPage = () => {
       .map((id) => promptMap.get(id))
       .filter((prompt): prompt is Prompt => Boolean(prompt));
   }, [promptMap, sortedIds]);
-  const isSorting = activeId !== null;
   const shouldVirtualize = orderedPrompts.length > VIRTUALIZATION_THRESHOLD;
   const isReorderEnabled = normalizedSearch.length === 0 && statusFilter === 'all';
   const isReorderPending = reorderPrompts.isPending || hasReorderSaveQueued;


### PR DESCRIPTION
## Summary
- add the missing @dnd-kit/modifiers dependency required by the prompts page drag-and-drop implementation
- declare the isSorting flag before its first usage to satisfy TypeScript ordering rules

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da8eb5645883259eecb96de8b101fb