### PR TITLE
Add admin OpenAI preview probe endpoint

### DIFF
--- a/backend/src/routes/v1/admin/news.routes.js
+++ b/backend/src/routes/v1/admin/news.routes.js
@@ -12,6 +12,11 @@ router.get(
   validateRequest({ query: previewPayloadQuerySchema }),
   newsGenerationController.previewPayload,
 );
+router.get(
+  '/preview-openai',
+  validateRequest({ query: previewPayloadQuerySchema }),
+  newsGenerationController.previewOpenAI,
+);
 
 module.exports = router;
 

--- a/backend/tests/admin.news.preview-openai.e2e.test.js
+++ b/backend/tests/admin.news.preview-openai.e2e.test.js
@@ -1,0 +1,163 @@
+const request = require('supertest');
+
+jest.mock('../src/services/auth.service', () => {
+  const actual = jest.requireActual('../src/services/auth.service');
+  return {
+    ...actual,
+    validateSessionToken: jest.fn(),
+  };
+});
+
+const app = require('../src/app');
+const authService = require('../src/services/auth.service');
+const { prisma } = require('../src/lib/prisma');
+const { __mockClient } = require('../src/lib/openai-client');
+
+const ORIGIN = 'http://localhost:5173';
+const TOKENS = {
+  admin: 'token-admin',
+  other: 'token-other',
+};
+
+const sessionForUser = (userId, email, role) => ({
+  session: {
+    id: `session-${userId}`,
+    userId,
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    user: {
+      id: userId,
+      email,
+      role,
+    },
+  },
+  renewed: false,
+});
+
+const withAuth = (token, req) => req.set('Origin', ORIGIN).set('Authorization', `Bearer ${token}`);
+
+const createPrompt = ({ userId, title, content, position, enabled = true }) =>
+  prisma.prompt.create({ data: { userId, title, content, position, enabled } });
+
+const createFeed = ({ ownerKey, title = 'Feed principal', url = 'https://example.com/feed.xml' }) =>
+  prisma.feed.create({ data: { ownerKey, title, url } });
+
+const createArticle = ({
+  feedId,
+  title,
+  contentSnippet = 'Resumo',
+  articleHtml = '<p>Conteúdo</p>',
+  publishedAt = new Date('2024-01-02T09:00:00.000Z'),
+  link = 'https://example.com/news',
+  guid = 'guid-news',
+  dedupeKey = 'dedupe-news',
+}) =>
+  prisma.article.create({
+    data: {
+      feedId,
+      title,
+      contentSnippet,
+      articleHtml,
+      publishedAt,
+      link,
+      guid,
+      dedupeKey,
+    },
+  });
+
+describe('GET /api/v1/admin/news/preview-openai', () => {
+  let adminUser;
+
+  beforeEach(async () => {
+    prisma.__reset();
+
+    __mockClient.responses.create.mockReset();
+    __mockClient.withOptions.mockClear();
+
+    adminUser = await prisma.allowedUser.create({ data: { email: 'admin@example.com', role: 'admin' } });
+
+    authService.validateSessionToken.mockImplementation(async ({ token }) => {
+      if (token === TOKENS.admin) {
+        return sessionForUser(adminUser.id, adminUser.email, 'admin');
+      }
+
+      if (token === TOKENS.other) {
+        return sessionForUser(999, 'user@example.com', 'user');
+      }
+
+      return null;
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the raw OpenAI response without envelope on success', async () => {
+    const ownerKey = String(adminUser.id);
+    await createPrompt({ userId: adminUser.id, title: 'Prompt base', content: 'Contexto', position: 0 });
+    const feed = await createFeed({ ownerKey });
+    const article = await createArticle({ feedId: feed.id, title: 'Notícia destacada' });
+
+    const rawOpenAIResponse = {
+      id: 'resp_456',
+      model: 'gpt-5-nano',
+      usage: { input_tokens: 100, output_tokens: 40 },
+      output: [
+        {
+          id: 'choice-1',
+          type: 'message',
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                type: 'output_text',
+                text: 'Prévia gerada para a notícia',
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    __mockClient.responses.create.mockResolvedValueOnce(rawOpenAIResponse);
+
+    const response = await withAuth(
+      TOKENS.admin,
+      request(app).get('/api/v1/admin/news/preview-openai').query({ news_id: article.id }),
+    )
+      .expect('Content-Type', /json/)
+      .expect(200);
+
+    expect(response.body).toEqual(rawOpenAIResponse);
+    expect(response.body).not.toHaveProperty('success');
+    expect(__mockClient.responses.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('bubbles up OpenAI error status and payload', async () => {
+    const ownerKey = String(adminUser.id);
+    await createPrompt({ userId: adminUser.id, title: 'Prompt base', content: 'Contexto', position: 0 });
+    const feed = await createFeed({ ownerKey });
+    const article = await createArticle({ feedId: feed.id, title: 'Notícia com erro' });
+
+    const error = new Error('OpenAI request failed with status 500');
+    error.status = 500;
+    error.payload = {
+      error: {
+        type: 'server_error',
+        code: 'internal',
+        message: 'Internal server error',
+      },
+    };
+
+    __mockClient.responses.create.mockRejectedValueOnce(error);
+
+    const response = await withAuth(
+      TOKENS.admin,
+      request(app).get('/api/v1/admin/news/preview-openai').query({ news_id: article.id }),
+    )
+      .expect('Content-Type', /json/)
+      .expect(500);
+
+    expect(response.body).toEqual(error.payload);
+  });
+});

--- a/backend/tests/post-generation.probe-openai.service.test.js
+++ b/backend/tests/post-generation.probe-openai.service.test.js
@@ -1,0 +1,122 @@
+const { prisma } = require('../src/lib/prisma');
+const postGenerationService = require('../src/services/post-generation.service');
+const { __mockClient } = require('../src/lib/openai-client');
+
+const createPrompt = ({ userId, title, content, position, enabled = true }) =>
+  prisma.prompt.create({ data: { userId, title, content, position, enabled } });
+
+const createFeed = ({ ownerKey, title = 'Feed de notícias', url = 'https://example.com/feed.xml' }) =>
+  prisma.feed.create({ data: { ownerKey, title, url } });
+
+const createArticle = ({
+  feedId,
+  title,
+  contentSnippet = 'Resumo da notícia',
+  articleHtml = '<p>Conteúdo detalhado</p>',
+  publishedAt = new Date('2024-01-01T12:00:00.000Z'),
+  link = 'https://example.com/news',
+  guid = 'guid-news',
+  dedupeKey = 'dedupe-news',
+}) =>
+  prisma.article.create({
+    data: {
+      feedId,
+      title,
+      contentSnippet,
+      articleHtml,
+      publishedAt,
+      link,
+      guid,
+      dedupeKey,
+    },
+  });
+
+describe('postGenerationService.probeOpenAIResponse', () => {
+  beforeEach(async () => {
+    prisma.__reset();
+    __mockClient.responses.create.mockReset();
+    __mockClient.withOptions.mockClear();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the raw OpenAI response payload on success', async () => {
+    const adminUser = await prisma.allowedUser.create({ data: { email: 'admin@example.com', role: 'admin' } });
+    const ownerKey = String(adminUser.id);
+    await createPrompt({ userId: adminUser.id, title: 'Prompt base', content: 'Contexto adicional', position: 0 });
+    const feed = await createFeed({ ownerKey });
+    const article = await createArticle({ feedId: feed.id, title: 'Notícia alvo' });
+
+    const rawResponse = {
+      id: 'resp_123',
+      model: 'gpt-5-nano',
+      output: [
+        {
+          id: 'choice-1',
+          type: 'message',
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                type: 'output_text',
+                text: 'Post gerado pela OpenAI',
+              },
+            ],
+          },
+        },
+      ],
+      usage: { input_tokens: 120, output_tokens: 80 },
+    };
+
+    __mockClient.responses.create.mockResolvedValueOnce(rawResponse);
+
+    const response = await postGenerationService.probeOpenAIResponse({
+      ownerKey,
+      newsId: article.id,
+    });
+
+    expect(response).toBe(rawResponse);
+    expect(__mockClient.withOptions).toHaveBeenCalledWith({ timeout: expect.any(Number) });
+    expect(__mockClient.responses.create).toHaveBeenCalledTimes(1);
+
+    const payload = __mockClient.responses.create.mock.calls[0][0];
+    expect(payload.model).toBe('gpt-5-nano');
+    expect(payload.input).toHaveLength(2);
+    expect(payload.input[0]).toEqual(
+      expect.objectContaining({
+        role: 'system',
+      }),
+    );
+    expect(payload.input[1]).toEqual(
+      expect.objectContaining({
+        role: 'user',
+      }),
+    );
+  });
+
+  it('propagates OpenAI errors with status and raw payload', async () => {
+    const adminUser = await prisma.allowedUser.create({ data: { email: 'admin@example.com', role: 'admin' } });
+    const ownerKey = String(adminUser.id);
+    await createPrompt({ userId: adminUser.id, title: 'Prompt base', content: 'Contexto adicional', position: 0 });
+    const feed = await createFeed({ ownerKey });
+    const article = await createArticle({ feedId: feed.id, title: 'Notícia alvo' });
+
+    const error = new Error('OpenAI request failed with status 429');
+    error.status = 429;
+    error.payload = {
+      error: {
+        type: 'rate_limit_error',
+        code: 'rate_limit',
+        message: 'Too many requests',
+      },
+    };
+
+    __mockClient.responses.create.mockRejectedValueOnce(error);
+
+    await expect(
+      postGenerationService.probeOpenAIResponse({ ownerKey, newsId: article.id }),
+    ).rejects.toEqual({ status: 429, payloadBruto: error.payload });
+  });
+});


### PR DESCRIPTION
## Summary
- add a probe service that reuses existing prompt and article logic to call OpenAI without persisting posts
- expose GET /api/v1/admin/news/preview-openai to return the raw upstream response or error payloads
- cover the new flow with unit and e2e tests to ensure success and error cases behave as expected

## Testing
- npm test -- post-generation.probe-openai.service admin.news.preview-openai.e2e

------
https://chatgpt.com/codex/tasks/task_e_68e06a52a76083259c5b7bbf0e0e3e02