### PR TITLE
Add OpenAI request preview to admin post modal

### DIFF
--- a/frontend/src/config/i18n.ts
+++ b/frontend/src/config/i18n.ts
@@ -375,6 +375,19 @@ const resources = {
           newsEmpty: 'News content is not available for this preview.',
           empty: 'No eligible news item is available for preview.',
           rowAction: 'Preview',
+          request: {
+            button: 'Preview Request',
+            loading: 'Loading request...',
+            title: 'OpenAI request payload',
+            placeholder: 'Load the request preview to inspect the raw payload.',
+            prettyToggle: 'Pretty print (visual)',
+            copyButton: 'Copy raw JSON',
+            copySuccess: 'Copied raw JSON to clipboard.',
+            textareaLabel: 'OpenAI raw response',
+            errors: {
+              network: 'Failed to call the API. Check the console for details.',
+            },
+          },
           errors: {
             network: 'We could not load the preview. Check your connection and try again.',
             generic: 'We could not load the preview. Try again.',
@@ -866,6 +879,19 @@ const resources = {
           newsEmpty: 'Conteudo da noticia indisponivel para esta pre-visualizacao.',
           empty: 'Nenhuma noticia elegivel disponivel para pre-visualizacao.',
           rowAction: 'Pre-visualizar',
+          request: {
+            button: 'Preview Request',
+            loading: 'Carregando request...',
+            title: 'Payload da requisicao OpenAI',
+            placeholder: 'Clique em "Preview Request" para carregar o payload bruto.',
+            prettyToggle: 'Pretty print (visual)',
+            copyButton: 'Copiar JSON bruto',
+            copySuccess: 'JSON bruto copiado para a area de transferencia.',
+            textareaLabel: 'Resposta bruta da OpenAI',
+            errors: {
+              network: 'Falha ao chamar a API. Veja o console para detalhes.',
+            },
+          },
           errors: {
             network: 'Nao foi possivel carregar a pre-visualizacao. Verifique sua conexao e tente novamente.',
             generic: 'Nao foi possivel carregar a pre-visualizacao. Tente novamente.',

--- a/frontend/src/features/posts/api/posts.ts
+++ b/frontend/src/features/posts/api/posts.ts
@@ -10,6 +10,7 @@ import {
 } from '../types/post';
 
 import { getJson, getJsonWithMeta, postJson, HttpError } from '@/lib/api/http';
+import { ENV } from '@/config/env';
 import { postRequestPreviewSchema, type PostRequestPreview } from '../types/post-preview';
 
 export const POSTS_QUERY_KEY = ['posts'] as const;
@@ -89,4 +90,36 @@ export const fetchPostRequestPreview = async (
 
     throw error;
   }
+};
+
+type FetchOpenAiPreviewRawParams = {
+  newsId: number;
+  signal?: AbortSignal;
+};
+
+export const fetchAdminOpenAiPreviewRaw = async ({
+  newsId,
+  signal,
+}: FetchOpenAiPreviewRawParams): Promise<string> => {
+  const searchParams = new URLSearchParams();
+  searchParams.set('news_id', String(newsId));
+
+  const url = new URL(`/api/v1/admin/news/preview-openai?${searchParams.toString()}`, ENV.API_URL);
+
+  const response = await fetch(url, {
+    method: 'GET',
+    credentials: 'include',
+    signal,
+    headers: {
+      Accept: 'application/json',
+    },
+  });
+
+  const rawBody = await response.text();
+
+  if (!response.ok) {
+    throw new HttpError(response.statusText || 'Request failed', response.status, rawBody);
+  }
+
+  return rawBody;
 };


### PR DESCRIPTION
## Summary
- add API helper and modal UI to fetch and display raw OpenAI request payloads with optional pretty-print and clipboard copy
- introduce localized strings for the new OpenAI preview controls in both English and Portuguese
- expand posts page tests to cover success, error, network failure, and abort behaviours for the new preview flow

## Testing
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68e06c9ac148832589135dc966170994