### PR TITLE
Fix Responses API payload types and broaden text extraction

### DIFF
--- a/backend/src/services/post-generation.service.js
+++ b/backend/src/services/post-generation.service.js
@@ -414,7 +414,7 @@ const buildNewsPayload = (article) => {
       role: 'user',
       content: [
         {
-          type: 'text',
+          type: 'input_text',
           text: context,
         },
       ],
@@ -640,7 +640,7 @@ const buildGenerationPayload = ({ article, basePrompt, model }) => {
         content: systemText
           ? [
               {
-                type: 'text',
+                type: 'input_text',
                 text: systemText,
               },
             ]
@@ -650,7 +650,7 @@ const buildGenerationPayload = ({ article, basePrompt, model }) => {
         role: 'user',
         content: [
           {
-            type: 'text',
+            type: 'input_text',
             text: context,
           },
         ],

--- a/backend/src/utils/openai-responses.js
+++ b/backend/src/utils/openai-responses.js
@@ -1,4 +1,4 @@
-const TEXTUAL_TYPES = new Set(['text', 'output_text']);
+const TEXTUAL_TYPES = new Set(['text', 'output_text', 'summary_text', 'refusal']);
 
 const pickFirstString = (value) => {
   if (typeof value === 'string' && value.trim().length > 0) {
@@ -22,7 +22,15 @@ const extractFromEntry = (entry) => {
     return null;
   }
 
-  const candidates = [entry.text, entry.data, entry.output_text, entry.value, entry.content];
+  const candidates = [
+    entry.text,
+    entry.data,
+    entry.output_text,
+    entry.summary_text,
+    entry.refusal,
+    entry.value,
+    entry.content,
+  ];
 
   for (const candidate of candidates) {
     const text = pickFirstString(candidate);

--- a/backend/tests/post-generation.integration.test.js
+++ b/backend/tests/post-generation.integration.test.js
@@ -93,7 +93,7 @@ describe('post-generation.service integration', () => {
               role: 'system',
               content: [
                 expect.objectContaining({
-                  type: 'text',
+                  type: 'input_text',
                   text: expect.stringContaining('Instrução final'),
                 }),
               ],
@@ -102,7 +102,7 @@ describe('post-generation.service integration', () => {
               role: 'user',
               content: [
                 expect.objectContaining({
-                  type: 'text',
+                  type: 'input_text',
                   text: expect.stringContaining('Notícia ID interno'),
                 }),
               ],

--- a/backend/tests/utils/openai-responses.test.js
+++ b/backend/tests/utils/openai-responses.test.js
@@ -15,7 +15,7 @@ describe('extractTextFromResponses', () => {
         {
           content: [
             { type: 'text', text: 'Primeiro parágrafo.' },
-            { type: 'output_text', data: 'Segundo parágrafo.' },
+            { type: 'output_text', text: 'Segundo parágrafo.' },
           ],
         },
         {
@@ -44,6 +44,30 @@ describe('extractTextFromResponses', () => {
     };
 
     expect(extractTextFromResponses(response)).toBeNull();
+  });
+
+  it('extracts text from summary_text entries', () => {
+    const response = {
+      output: [
+        {
+          content: [{ type: 'summary_text', text: 'Resumo final.' }],
+        },
+      ],
+    };
+
+    expect(extractTextFromResponses(response)).toBe('Resumo final.');
+  });
+
+  it('extracts text from refusal entries', () => {
+    const response = {
+      output: [
+        {
+          content: [{ type: 'refusal', text: 'Solicitação recusada.' }],
+        },
+      ],
+    };
+
+    expect(extractTextFromResponses(response)).toBe('Solicitação recusada.');
   });
 });
 


### PR DESCRIPTION
## Summary
- switch Responses API request payloads to use `input_text` for system and user content blocks
- extend response parsing utilities to accept `summary_text` and `refusal` entries alongside existing text types
- update tests to cover the new payload shape and parsing scenarios

## Testing
- `npm test -- --runTestsByPath tests/utils/openai-responses.test.js tests/post-generation.integration.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68e073fae4808325bb9ffe93b87ad802