### PR TITLE
Improve mobile navigation experience

### DIFF
--- a/frontend/src/app/layout/MainLayout.tsx
+++ b/frontend/src/app/layout/MainLayout.tsx
@@ -9,10 +9,10 @@ export const MainLayout = () => {
   return (
     <div className="flex min-h-screen flex-col bg-background text-foreground">
       <TopNav />
-      <main id="conteudo" className="container-responsive flex-1 py-10">
+      <main id="conteudo" className="container-responsive flex-1 py-6 sm:py-10">
         <Outlet />
       </main>
-      <footer className="border-t border-border bg-surface/50 py-6 text-sm text-muted-foreground">
+      <footer className="border-t border-border bg-surface/50 py-6 text-sm text-muted-foreground sm:py-8">
         <div className="container-responsive flex flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between">
           <p>&copy; {new Date().getFullYear()} lkdposts. {t('footer.rights')}</p>
           <p>{t('footer.version', { version: __APP_VERSION__ })}</p>

--- a/frontend/src/components/navigation/LanguageSwitcher.tsx
+++ b/frontend/src/components/navigation/LanguageSwitcher.tsx
@@ -1,5 +1,6 @@
 import { ChangeEvent, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { clsx } from 'clsx';
 
 const SUPPORTED_LOCALES = [
   { value: 'pt-BR', label: '\u{1F1E7}\u{1F1F7} Português' },
@@ -8,7 +9,12 @@ const SUPPORTED_LOCALES = [
 
 const LANGUAGE_STORAGE_KEY = 'lkdposts-language';
 
-export const LanguageSwitcher = () => {
+type LanguageSwitcherProps = {
+  className?: string;
+  selectClassName?: string;
+};
+
+export const LanguageSwitcher = ({ className, selectClassName }: LanguageSwitcherProps) => {
   const { i18n } = useTranslation();
 
   const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
@@ -38,12 +44,17 @@ export const LanguageSwitcher = () => {
   }, [i18n]);
 
   return (
-    <label className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+    <label
+      className={clsx('flex items-center gap-2 text-sm font-medium text-muted-foreground', className)}
+    >
       <span className="sr-only">Idioma</span>
       <select
         value={i18n.language}
         onChange={handleChange}
-        className="min-w-[10rem] rounded-md border border-border bg-surface px-3 py-1 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-ring"
+        className={clsx(
+          'w-full rounded-md border border-border bg-surface px-3 py-1 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-ring sm:w-auto sm:min-w-[10rem]',
+          selectClassName,
+        )}
         aria-label="Selecionar idioma"
       >
         {SUPPORTED_LOCALES.map((locale) => (

--- a/frontend/src/components/navigation/TopNav.tsx
+++ b/frontend/src/components/navigation/TopNav.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Link, NavLink } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
@@ -11,6 +12,9 @@ import { HttpError } from '@/lib/api/http';
 export const TopNav = () => {
   const { t } = useTranslation();
   const { status, user, logout, isAuthenticating } = useAuth();
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const toggleButtonRef = useRef<HTMLButtonElement | null>(null);
 
   const links: Array<{ to: string; label: string }> =
     status === 'authenticated'
@@ -36,11 +40,76 @@ export const TopNav = () => {
     });
   };
 
+  const closeMenu = useCallback(() => {
+    setIsMenuOpen(false);
+    setTimeout(() => {
+      toggleButtonRef.current?.focus();
+    }, 0);
+  }, []);
+
+  useEffect(() => {
+    if (!isMenuOpen) {
+      return;
+    }
+
+    const rootDocument = 'document' in globalThis ? globalThis.document : undefined;
+
+    if (!rootDocument) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        closeMenu();
+      }
+    };
+
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (menuRef.current?.contains(target)) {
+        return;
+      }
+
+      if (toggleButtonRef.current?.contains(target)) {
+        return;
+      }
+
+      closeMenu();
+    };
+
+    const previousOverflow = rootDocument.body.style.overflow;
+    rootDocument.body.style.overflow = 'hidden';
+
+    rootDocument.addEventListener('keydown', handleKeyDown);
+    rootDocument.addEventListener('mousedown', handleClickOutside);
+
+    return () => {
+      rootDocument.body.style.overflow = previousOverflow;
+      rootDocument.removeEventListener('keydown', handleKeyDown);
+      rootDocument.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [closeMenu, isMenuOpen]);
+
+  const desktopLinkClassName = useCallback(
+    ({ isActive }: { isActive: boolean }) =>
+      clsx(
+        'rounded-md px-3 py-2 transition-colors duration-200',
+        isActive ? 'bg-primary/10 text-primary' : 'hover:bg-muted hover:text-foreground',
+      ),
+    [],
+  );
+
   let authSection: ReactNode;
+  let authSectionMobile: ReactNode;
 
   if (status === 'unknown') {
     authSection = (
       <span className="text-xs text-muted-foreground">{t('navigation.checking', 'Verificando...')}</span>
+    );
+    authSectionMobile = (
+      <span className="block text-sm text-muted-foreground">
+        {t('navigation.checking', 'Verificando...')}
+      </span>
     );
   } else if (status === 'authenticated') {
     authSection = (
@@ -58,9 +127,30 @@ export const TopNav = () => {
         </button>
       </div>
     );
+    authSectionMobile = (
+      <div className="space-y-2 rounded-md border border-border bg-muted/30 p-4">
+        <span className="block text-sm font-medium text-foreground">{user?.email}</span>
+        <button
+          type="button"
+          className="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+          onClick={handleLogout}
+          disabled={isAuthenticating}
+        >
+          {isAuthenticating ? t('navigation.signingOut', 'Saindo...') : t('navigation.logout', 'Sair')}
+        </button>
+      </div>
+    );
   } else {
     authSection = (
       <a href="/" className="text-sm font-medium text-primary hover:underline">
+        {t('navigation.signIn', 'Entrar')}
+      </a>
+    );
+    authSectionMobile = (
+      <a
+        href="/"
+        className="block w-full rounded-md bg-primary px-4 py-2 text-center text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90"
+      >
         {t('navigation.signIn', 'Entrar')}
       </a>
     );
@@ -72,27 +162,18 @@ export const TopNav = () => {
         {t('navigation.skipToContent')}
       </a>
       <div className="container-responsive flex h-16 items-center justify-between gap-4">
-        <div className="flex items-center gap-6">
+        <div className="flex flex-1 items-center gap-6">
           <Link
             to={status === 'authenticated' ? '/posts' : '/'}
             className="text-lg font-display font-semibold tracking-tight text-primary"
           >
             LinkedIn Posts
           </Link>
-          <nav aria-label={t('navigation.primary')}>
+          <nav aria-label={t('navigation.primary')} className="hidden sm:block">
             <ul className="flex items-center gap-3 text-sm font-medium text-muted-foreground">
               {links.map((link) => (
                 <li key={link.to}>
-                  <NavLink
-                    to={link.to}
-                    end={link.to === '/'}
-                    className={({ isActive }) =>
-                      clsx(
-                        'rounded-md px-3 py-2 transition-colors duration-200',
-                        isActive ? 'bg-primary/10 text-primary' : 'hover:bg-muted hover:text-foreground'
-                      )
-                    }
-                  >
+                  <NavLink to={link.to} end={link.to === '/'} className={desktopLinkClassName}>
                     {link.label}
                   </NavLink>
                 </li>
@@ -100,12 +181,77 @@ export const TopNav = () => {
             </ul>
           </nav>
         </div>
-        <div className="flex items-center gap-3">
+        <div className="hidden items-center gap-3 sm:flex">
           <LanguageSwitcher />
           <ThemeToggle />
           {authSection}
         </div>
+        <div className="flex items-center gap-2 sm:hidden">
+          <ThemeToggle />
+          <button
+            type="button"
+            ref={toggleButtonRef}
+            className="inline-flex items-center justify-center rounded-md border border-border px-3 py-2 text-sm font-medium text-foreground shadow-sm transition hover:bg-muted"
+            onClick={() => setIsMenuOpen((prev) => !prev)}
+            aria-expanded={isMenuOpen}
+            aria-controls="mobile-menu"
+          >
+            <span className="sr-only">{isMenuOpen ? t('navigation.closeMenu', 'Fechar menu') : t('navigation.openMenu', 'Abrir menu')}</span>
+            <svg aria-hidden className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+              {isMenuOpen ? (
+                <path
+                  fillRule="evenodd"
+                  d="M5.22 5.22a.75.75 0 0 1 1.06 0L10 8.94l3.72-3.72a.75.75 0 0 1 1.06 1.06L11.06 10l3.72 3.72a.75.75 0 0 1-1.06 1.06L10 11.06l-3.72 3.72a.75.75 0 0 1-1.06-1.06L8.94 10 5.22 6.28a.75.75 0 0 1 0-1.06Z"
+                  clipRule="evenodd"
+                />
+              ) : (
+                <path
+                  fillRule="evenodd"
+                  d="M3.75 5A.75.75 0 0 1 4.5 4.25h11a.75.75 0 0 1 0 1.5h-11A.75.75 0 0 1 3.75 5Zm0 5a.75.75 0 0 1 .75-.75h11a.75.75 0 0 1 0 1.5h-11A.75.75 0 0 1 3.75 10Zm0 5a.75.75 0 0 1 .75-.75h11a.75.75 0 0 1 0 1.5h-11a.75.75 0 0 1-.75-.75Z"
+                  clipRule="evenodd"
+                />
+              )}
+            </svg>
+          </button>
+        </div>
       </div>
+      {isMenuOpen ? (
+        <div className="sm:hidden" role="dialog" aria-modal="true">
+          <div className="fixed inset-0 z-40 bg-background/60 backdrop-blur-sm" />
+          <div
+            id="mobile-menu"
+            ref={menuRef}
+            className="fixed inset-x-4 top-20 z-50 overflow-hidden rounded-lg border border-border bg-background shadow-xl"
+          >
+            <div className="space-y-6 p-6">
+              <nav aria-label={t('navigation.primary')} className="space-y-2">
+                {links.map((link) => (
+                  <NavLink
+                    key={link.to}
+                    to={link.to}
+                    end={link.to === '/'}
+                    className={({ isActive }) =>
+                      clsx(
+                        'block rounded-md px-4 py-2 text-base font-medium transition-colors',
+                        isActive
+                          ? 'bg-primary text-primary-foreground'
+                          : 'text-foreground hover:bg-muted hover:text-foreground',
+                      )
+                    }
+                    onClick={closeMenu}
+                  >
+                    {link.label}
+                  </NavLink>
+                ))}
+              </nav>
+              <div className="space-y-4">
+                <LanguageSwitcher className="flex-col items-start gap-3" selectClassName="sm:min-w-0" />
+                {authSectionMobile}
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </header>
   );
 };

--- a/frontend/src/pages/home/HomePage.tsx
+++ b/frontend/src/pages/home/HomePage.tsx
@@ -42,7 +42,7 @@ const HomePage = () => {
           )}
         </div>
       </section>
-      <div className="card space-y-3 px-8 py-10 text-center">
+      <div className="card space-y-3 px-6 py-8 text-center sm:px-8 sm:py-10">
         <h2 className="text-lg font-semibold text-foreground">{t('home.auth.title', 'Autenticacao necessaria')}</h2>
         <p className="text-sm text-muted-foreground">{t('home.auth.description', 'Entre com sua conta Google autorizada para acessar o conteudo.')}</p>
       </div>


### PR DESCRIPTION
## Summary
- add an accessible mobile drawer to the top navigation and keep the desktop layout intact
- make the language selector reusable so it adapts to narrow viewports and tune the main layout spacing for small screens
- soften the home authentication card padding so the content fits comfortably on phones

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e0799ae6288325aa1844f27f691c91