### PR TITLE
Improve responsive layouts for mobile across admin pages

### DIFF
--- a/frontend/src/pages/allowlist/AllowlistPage.tsx
+++ b/frontend/src/pages/allowlist/AllowlistPage.tsx
@@ -184,7 +184,7 @@ export const AllowlistPage = () => {
         </p>
       </header>
 
-      <section className="card space-y-4 px-6 py-6">
+      <section className="card space-y-4 px-4 py-6 sm:px-6">
         <h2 className="text-lg font-medium text-foreground">{t('allowlist.form.title', 'Adicionar email')}</h2>
         <form className="grid gap-4 sm:grid-cols-[2fr,1fr,auto]" onSubmit={handleSubmit}>
           <label className="text-sm">
@@ -207,7 +207,7 @@ export const AllowlistPage = () => {
             <select
               value={role}
               onChange={(event) => setRole(event.target.value as AllowedRole)}
-              className="w-full min-w-[8rem] rounded-md border border-border bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+              className="w-full min-w-0 rounded-md border border-border bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40 sm:min-w-[8rem]"
               disabled={isBusy}
             >
               <option value="user">{t('allowlist.roles.user', 'Usuario')}</option>

--- a/frontend/src/pages/app-params/AppParamsPage.tsx
+++ b/frontend/src/pages/app-params/AppParamsPage.tsx
@@ -407,7 +407,7 @@ const AppParamsPage = () => {
             <button
               type="button"
               onClick={handleRetry}
-              className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90"
+              className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
               disabled={appParams.isFetching}
             >
               {appParams.isFetching
@@ -516,14 +516,14 @@ const AppParamsPage = () => {
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
           <button
             type="submit"
-            className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+            className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
             disabled={!canSave}
           >
             {isSaving ? t('appParams.actions.saving', 'Salvando...') : t('appParams.actions.save', 'Salvar')}
           </button>
           <button
             type="button"
-            className="inline-flex items-center justify-center rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+            className="inline-flex w-full items-center justify-center rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
             onClick={() => {
               if (!params) {
                 return;

--- a/frontend/src/pages/feeds/FeedsPage.tsx
+++ b/frontend/src/pages/feeds/FeedsPage.tsx
@@ -521,7 +521,7 @@ const FeedsPage = () => {
     return (
       <div className="rounded-md border border-border p-4">
         <h3 className="text-sm font-semibold text-foreground">{t('feeds.bulkForm.summary.title', 'Resumo da operacao')}</h3>
-        <div className="mt-4 grid gap-4 md:grid-cols-3">
+        <div className="mt-4 grid gap-4 sm:grid-cols-2 md:grid-cols-3">
           <div className="space-y-3">
             <h4 className="text-sm font-medium text-foreground">{t('feeds.bulkForm.summary.created', { count: created.length })}</h4>
             {createdContent}
@@ -542,7 +542,7 @@ const FeedsPage = () => {
   const renderTableContent = () => {
     if (isLoading) {
       return (
-        <div className="px-6 py-6 text-sm text-muted-foreground">
+        <div className="px-4 py-6 text-sm text-muted-foreground sm:px-6">
           {t('feeds.list.loading', 'Carregando feeds...')}
         </div>
       );
@@ -550,7 +550,7 @@ const FeedsPage = () => {
 
     if (isError) {
       return (
-        <div className="px-6 py-6 text-sm text-destructive" role="alert">
+        <div className="px-4 py-6 text-sm text-destructive sm:px-6" role="alert">
           {t('feeds.list.error', 'Nao foi possivel carregar os feeds. Tente novamente mais tarde.')}
         </div>
       );
@@ -615,7 +615,7 @@ const FeedsPage = () => {
                       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
                         <button
                           type="button"
-                          className="inline-flex items-center justify-center rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+                          className="inline-flex w-full items-center justify-center rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
                           onClick={handleCancelEdit}
                           disabled={isUpdating}
                         >
@@ -623,7 +623,7 @@ const FeedsPage = () => {
                         </button>
                         <button
                           type="submit"
-                          className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+                          className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
                           disabled={isUpdating}
                         >
                           {isUpdating
@@ -662,10 +662,10 @@ const FeedsPage = () => {
                       : t('feeds.list.neverFetched', 'Ainda nao processado')}
                   </td>
                   <td className="px-6 py-4 align-top text-right text-sm">
-                    <div className="flex flex-col items-end gap-2 sm:flex-row sm:justify-end">
+                    <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center sm:justify-end">
                       <button
                         type="button"
-                        className="inline-flex items-center justify-center rounded-md border border-border px-3 py-2 text-xs font-medium text-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+                        className="inline-flex w-full items-center justify-center rounded-md border border-border px-3 py-2 text-xs font-medium text-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
                         onClick={() => handleStartEditing(feed)}
                         disabled={isUpdating || isDeleting}
                       >
@@ -673,7 +673,7 @@ const FeedsPage = () => {
                       </button>
                       <button
                         type="button"
-                        className="inline-flex items-center justify-center rounded-md border border-destructive px-3 py-2 text-xs font-medium text-destructive transition hover:bg-destructive hover:text-destructive-foreground disabled:cursor-not-allowed disabled:opacity-60"
+                        className="inline-flex w-full items-center justify-center rounded-md border border-destructive px-3 py-2 text-xs font-medium text-destructive transition hover:bg-destructive hover:text-destructive-foreground disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
                         onClick={() => handleDelete(feed)}
                         disabled={isDeleting || isUpdating}
                       >
@@ -722,7 +722,7 @@ const FeedsPage = () => {
         </p>
       </header>
 
-      <section className="card space-y-4 px-6 py-6">
+      <section className="card space-y-4 px-4 py-6 sm:px-6">
         <h2 className="text-lg font-medium text-foreground">{t('feeds.form.title', 'Adicionar feed')}</h2>
         <form className="grid gap-4 md:grid-cols-[2fr,1fr,auto]" onSubmit={handleCreateSubmit} noValidate>
           <label className="text-sm">
@@ -765,7 +765,7 @@ const FeedsPage = () => {
         ) : null}
       </section>
 
-      <section className="card space-y-4 px-6 py-6">
+      <section className="card space-y-4 px-4 py-6 sm:px-6">
         <h2 className="text-lg font-medium text-foreground">{t('feeds.bulkForm.title', 'Adicionar feeds em lote')}</h2>
         <form className="space-y-4" onSubmit={handleBulkSubmit} noValidate>
           <label className="text-sm">
@@ -785,7 +785,7 @@ const FeedsPage = () => {
             </p>
             <button
               type="submit"
-              className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
               disabled={isBulkCreating}
             >
               {isBulkCreating ? t('feeds.bulkForm.adding', 'Processando...') : t('feeds.bulkForm.submit', 'Adicionar em lote')}
@@ -801,7 +801,7 @@ const FeedsPage = () => {
       </section>
 
       <section className="card overflow-hidden">
-        <div className="flex flex-col gap-2 border-b border-border px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-2 border-b border-border px-4 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-6">
           <div>
             <h2 className="text-lg font-medium text-foreground">{t('feeds.list.title', 'Feeds do usuario')}</h2>
             <p className="text-xs text-muted-foreground">
@@ -811,11 +811,11 @@ const FeedsPage = () => {
               })}
             </p>
           </div>
-          <div className="flex flex-col items-end gap-2 sm:items-start">
-            {isAdmin ? (
-              <button
-                type="button"
-                className="inline-flex items-center justify-center rounded-md border border-destructive px-3 py-2 text-xs font-medium text-destructive transition hover:bg-destructive hover:text-destructive-foreground disabled:cursor-not-allowed disabled:opacity-60"
+        <div className="flex w-full flex-col items-start gap-2 sm:w-auto sm:items-end sm:text-right">
+          {isAdmin ? (
+            <button
+              type="button"
+              className="inline-flex w-full items-center justify-center rounded-md border border-destructive px-3 py-2 text-xs font-medium text-destructive transition hover:bg-destructive hover:text-destructive-foreground disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
                 onClick={() => {
                   void handleResetFeeds();
                 }}
@@ -837,12 +837,12 @@ const FeedsPage = () => {
           </div>
         </div>
         {renderTableContent()}
-        <div className="flex items-center justify-between border-t border-border px-6 py-4 text-sm text-muted-foreground">
+        <div className="flex flex-col gap-3 border-t border-border px-4 py-4 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between sm:px-6">
           <div>{t('feeds.list.pagination.page', { page: currentPage })}</div>
-          <div className="flex items-center gap-3">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
             <button
               type="button"
-              className="inline-flex items-center justify-center rounded-md border border-border px-3 py-1 text-xs font-medium text-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex w-full items-center justify-center rounded-md border border-border px-3 py-1 text-xs font-medium text-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
               onClick={handlePreviousPage}
               disabled={!hasPreviousPage || isLoading}
             >
@@ -850,7 +850,7 @@ const FeedsPage = () => {
             </button>
             <button
               type="button"
-              className="inline-flex items-center justify-center rounded-md border border-border px-3 py-1 text-xs font-medium text-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex w-full items-center justify-center rounded-md border border-border px-3 py-1 text-xs font-medium text-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
               onClick={handleNextPage}
               disabled={!hasNextPage || isLoading}
             >

--- a/frontend/src/pages/posts/PostsPage.tsx
+++ b/frontend/src/pages/posts/PostsPage.tsx
@@ -1386,14 +1386,14 @@ const PostsPage = () => {
         </p>
       </div>
 
-      <div className="flex flex-col gap-4 rounded-md border border-border bg-card px-6 py-4 sm:flex-row sm:items-end sm:justify-between">
+      <div className="flex flex-col gap-4 rounded-md border border-border bg-card px-4 py-4 sm:flex-row sm:items-end sm:justify-between sm:px-6">
         <div className="flex flex-col gap-2">
           <label className="text-xs font-medium text-muted-foreground" htmlFor="feed-filter">
             {t('posts.filters.feedLabel', 'Filter by feed')}
           </label>
           <select
             id="feed-filter"
-            className="w-full min-w-[16rem] rounded-md border border-border bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+            className="w-full min-w-0 rounded-md border border-border bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40 sm:min-w-[16rem]"
             value={selectedFeedId ?? ''}
             onChange={handleFeedChange}
             disabled={feedList.isLoading || feedList.isFetching || (!hasFeeds && feedList.isSuccess)}
@@ -1411,7 +1411,7 @@ const PostsPage = () => {
             </p>
           ) : null}
         </div>
-        <div className="flex flex-col items-start gap-2 sm:items-end">
+        <div className="flex w-full flex-col items-start gap-2 sm:w-auto sm:items-end">
           {isSyncing || isFetching ? (
             <span className="text-xs text-muted-foreground">{t('posts.messages.syncing', 'Syncing...')}</span>
           ) : null}
@@ -1423,7 +1423,7 @@ const PostsPage = () => {
           <button
             type="button"
             className={clsx(
-              'inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60',
+              'inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto',
               !isSyncing && isCooldownActive ? 'cursor-not-allowed opacity-60' : null,
             )}
             onClick={() => runSequence({ resetPagination: true })}
@@ -1435,7 +1435,7 @@ const PostsPage = () => {
           {isAdmin ? (
             <button
               type="button"
-              className="inline-flex items-center justify-center rounded-md border border-border px-3 py-1 text-xs font-medium text-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex w-full items-center justify-center rounded-md border border-border px-3 py-1 text-xs font-medium text-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
               onClick={() => handleOpenPreview()}
               disabled={previewIsLoading}
               aria-disabled={previewIsLoading}
@@ -1463,7 +1463,7 @@ const PostsPage = () => {
             <button
               type="button"
               className={clsx(
-                'mt-3 inline-flex items-center justify-center rounded-md border border-border px-3 py-1 text-xs font-medium text-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60',
+                'mt-3 inline-flex w-full items-center justify-center rounded-md border border-border px-3 py-1 text-xs font-medium text-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto',
                 !isSyncing && isCooldownActive ? 'cursor-not-allowed opacity-60' : null,
               )}
               onClick={() => runSequence()}
@@ -1484,7 +1484,7 @@ const PostsPage = () => {
             <button
               type="button"
               className={clsx(
-                'mt-3 inline-flex items-center justify-center rounded-md border border-border px-3 py-1 text-xs font-medium text-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60',
+                'mt-3 inline-flex w-full items-center justify-center rounded-md border border-border px-3 py-1 text-xs font-medium text-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto',
                 !isSyncing && isCooldownActive ? 'cursor-not-allowed opacity-60' : null,
               )}
               onClick={() => runSequence()}

--- a/frontend/src/pages/prompts/PromptsPage.tsx
+++ b/frontend/src/pages/prompts/PromptsPage.tsx
@@ -1822,8 +1822,8 @@ const PromptsPage = () => {
         </p>
       </header>
 
-      <div className="flex flex-wrap items-end gap-3">
-        <div className="min-w-[220px] flex-1">
+      <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
+        <div className="w-full sm:flex-1 sm:min-w-[220px]">
           <label htmlFor="prompt-search" className="text-sm font-medium text-foreground">
             {t('prompts.search.label', 'Search prompts')}
           </label>
@@ -1837,7 +1837,7 @@ const PromptsPage = () => {
             autoComplete="off"
           />
         </div>
-        <div className="min-w-[180px]">
+        <div className="w-full sm:w-auto sm:min-w-[180px]">
           <label htmlFor="prompt-status-filter" className="text-sm font-medium text-foreground">
             {t('prompts.filter.status.label', 'Status filter')}
           </label>
@@ -1852,11 +1852,11 @@ const PromptsPage = () => {
             <option value="disabled">{t('prompts.filter.status.disabled', 'Disabled')}</option>
           </select>
         </div>
-        <div className="ml-auto flex flex-wrap items-center gap-2">
+        <div className="flex w-full flex-col gap-2 sm:ml-auto sm:w-auto sm:flex-row sm:flex-wrap sm:items-center">
           <button
             type="button"
             onClick={handleOpenCreateForm}
-            className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+            className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
             disabled={isSaving}
           >
             {t('prompts.actions.new', 'New prompt')}
@@ -1864,7 +1864,7 @@ const PromptsPage = () => {
           <button
             type="button"
             onClick={handleOpenExportModal}
-            className="inline-flex items-center justify-center rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground shadow-sm transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+            className="inline-flex w-full items-center justify-center rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground shadow-sm transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
             disabled={!hasSelection}
           >
             {t('prompts.actions.exportSelected', 'Export selected')}
@@ -1887,7 +1887,7 @@ const PromptsPage = () => {
               : 'border-danger/30 bg-danger/10 text-danger',
           )}
         >
-          <div className="flex flex-wrap items-center gap-3">
+          <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:gap-3">
             <span>{feedback.message}</span>
             {feedback.action ? (
               <button
@@ -1908,8 +1908,8 @@ const PromptsPage = () => {
       ) : null}
 
       {isFormOpen ? (
-        <form onSubmit={handleSubmit} className="card space-y-4 p-6" noValidate>
-          <div className="flex flex-wrap items-center justify-between gap-2">
+        <form onSubmit={handleSubmit} className="card space-y-4 p-4 sm:p-6" noValidate>
+          <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
             <h2 className="text-lg font-semibold text-foreground">
               {formMode === 'create'
                 ? t('prompts.form.createTitle', 'Create prompt')
@@ -1918,7 +1918,7 @@ const PromptsPage = () => {
             <button
               type="button"
               onClick={handleCancelForm}
-              className="inline-flex items-center justify-center rounded-md border border-border px-3 py-1.5 text-sm font-medium text-foreground transition hover:bg-muted"
+              className="inline-flex w-full items-center justify-center rounded-md border border-border px-3 py-1.5 text-sm font-medium text-foreground transition hover:bg-muted sm:w-auto"
             >
               {t('prompts.actions.cancel', 'Cancel')}
             </button>
@@ -1945,7 +1945,7 @@ const PromptsPage = () => {
           </div>
 
           <div className="space-y-2">
-            <div className="flex items-center justify-between gap-2">
+            <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between">
               <label htmlFor="prompt-content" className="text-sm font-medium text-foreground">
                 {t('prompts.form.contentLabel', 'Content')}
               </label>
@@ -1980,10 +1980,10 @@ const PromptsPage = () => {
             ) : null}
           </div>
 
-          <div className="flex items-center justify-end gap-2">
+          <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
             <button
               type="submit"
-              className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
               disabled={isSaving}
             >
               {isSaving
@@ -2016,7 +2016,7 @@ const PromptsPage = () => {
                 setFeedback(null);
                 refetchPromptList();
               }}
-              className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90"
+              className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90 sm:w-auto"
             >
               {t('prompts.actions.retry', 'Try again')}
             </button>
@@ -2032,7 +2032,7 @@ const PromptsPage = () => {
             <button
               type="button"
               onClick={handleOpenCreateForm}
-              className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90"
+              className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90 sm:w-auto"
             >
               {t('prompts.actions.createFirst', 'Create prompt')}
             </button>
@@ -2209,7 +2209,7 @@ const PromptsPage = () => {
                 aria-labelledby="export-modal-title"
                 className="w-full max-w-2xl rounded-lg border border-border bg-background p-6 shadow-lg"
               >
-                <div className="flex items-start justify-between gap-4">
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
                   <div className="space-y-1">
                     <h2 id="export-modal-title" className="text-lg font-semibold text-foreground">
                       {t('prompts.export.title', 'Export selected prompts')}
@@ -2224,7 +2224,7 @@ const PromptsPage = () => {
                   <button
                     type="button"
                     onClick={handleCloseExportModal}
-                    className="inline-flex items-center justify-center rounded-md border border-border px-3 py-1.5 text-sm font-medium text-foreground transition hover:bg-muted"
+                    className="inline-flex w-full items-center justify-center rounded-md border border-border px-3 py-1.5 text-sm font-medium text-foreground transition hover:bg-muted sm:w-auto"
                   >
                     {t('prompts.export.close', 'Close')}
                   </button>
@@ -2246,7 +2246,7 @@ const PromptsPage = () => {
                     className="h-64 w-full resize-none rounded-md border border-border bg-muted/40 px-3 py-2 text-sm text-foreground focus:outline-none"
                   />
                 </div>
-                <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+                <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
                   <div className="text-sm">
                     {copyStatus === 'success' ? (
                       <p className="text-primary">
@@ -2266,7 +2266,7 @@ const PromptsPage = () => {
                         console.error('[PromptsPage] Failed to copy export content', error);
                       });
                     }}
-                    className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90"
+                    className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90 sm:w-auto"
                   >
                     {t('prompts.export.copy', 'Copy')}
                   </button>


### PR DESCRIPTION
## Summary
- adjust allowlist, feeds, posts, prompts, and app params layouts to provide roomier spacing and full-width actions on small screens
- update forms, tables, and modals to avoid hard minimum widths and stack controls naturally on mobile while preserving desktop behavior
- align card padding across pages for better consistency between mobile and larger viewports

## Testing
- npm run lint *(fails: pre-existing eslint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e07bff98d48325adc9161db7c710a6