### PR TITLE
fix: improve dialog semantics and status messaging

### DIFF
--- a/frontend/src/components/navigation/TopNav.tsx
+++ b/frontend/src/components/navigation/TopNav.tsx
@@ -13,7 +13,7 @@ export const TopNav = () => {
   const { t } = useTranslation();
   const { status, user, logout, isAuthenticating } = useAuth();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement | null>(null);
+  const menuRef = useRef<HTMLDialogElement | null>(null);
   const toggleButtonRef = useRef<HTMLButtonElement | null>(null);
   const settingsMenuRef = useRef<HTMLDivElement | null>(null);
   const settingsToggleRef = useRef<HTMLButtonElement | null>(null);
@@ -332,12 +332,15 @@ export const TopNav = () => {
         </div>
       </div>
       {isMenuOpen ? (
-        <div className="sm:hidden" role="dialog" aria-modal="true">
-          <div className="fixed inset-0 z-40 bg-background/60 backdrop-blur-sm" />
-          <div
+        <div className="sm:hidden">
+          <div className="fixed inset-0 z-40 bg-background/60 backdrop-blur-sm" aria-hidden="true" />
+          <dialog
             id="mobile-menu"
             ref={menuRef}
             className="fixed inset-x-4 top-20 z-50 overflow-hidden rounded-lg border border-border bg-background shadow-xl"
+            open
+            aria-modal="true"
+            aria-label={t('navigation.mobileMenu', 'Navigation menu')}
           >
             <div className="space-y-6 p-6">
               <nav aria-label={t('navigation.primary')} className="space-y-4">
@@ -391,7 +394,7 @@ export const TopNav = () => {
                 {authSectionMobile}
               </div>
             </div>
-          </div>
+          </dialog>
         </div>
       ) : null}
     </header>

--- a/frontend/src/pages/feeds/FeedsPage.tsx
+++ b/frontend/src/pages/feeds/FeedsPage.tsx
@@ -81,12 +81,16 @@ const buildFeedbackClassName = (feedback: FeedbackMessage | null) => {
   return feedback.type === 'success' ? 'text-sm text-primary' : 'text-sm text-destructive';
 };
 
-const buildFeedbackRole = (feedback: FeedbackMessage | null) => {
+const buildFeedbackAccessibilityProps = (feedback: FeedbackMessage | null) => {
   if (!feedback) {
-    return undefined;
+    return {} as const;
   }
 
-  return feedback.type === 'error' ? 'alert' : 'status';
+  if (feedback.type === 'error') {
+    return { role: 'alert', 'aria-live': 'assertive' as const, 'aria-atomic': true as const };
+  }
+
+  return { 'aria-live': 'polite' as const, 'aria-atomic': true as const };
 };
 
 const FeedsPage = () => {
@@ -632,7 +636,10 @@ const FeedsPage = () => {
                         </label>
                       </div>
                       {editFeedback ? (
-                        <p className={buildFeedbackClassName(editFeedback)} role={buildFeedbackRole(editFeedback)}>
+                        <p
+                          className={buildFeedbackClassName(editFeedback)}
+                          {...buildFeedbackAccessibilityProps(editFeedback)}
+                        >
                           {editFeedback.message}
                         </p>
                       ) : null}
@@ -740,13 +747,14 @@ const FeedsPage = () => {
   const deleteDialog =
     feedPendingDeletion && typeof document !== 'undefined'
       ? createPortal(
-          <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 px-4 py-6 backdrop-blur">
-            <div
-              role="dialog"
-              aria-modal="true"
+          <div className="fixed inset-0 z-50 flex items-center justify-center px-4 py-6">
+            <div className="fixed inset-0 bg-background/80 backdrop-blur" aria-hidden="true" />
+            <dialog
               aria-labelledby={deleteDialogTitleId}
               aria-describedby={deleteDialogDescriptionId}
-              className="w-full max-w-md space-y-6 rounded-lg border border-border bg-background p-6 shadow-lg"
+              className="relative z-10 w-full max-w-md space-y-6 rounded-lg border border-border bg-background p-6 shadow-lg"
+              aria-modal="true"
+              open
             >
               <div className="space-y-2">
                 <h2 id={deleteDialogTitleId} className="text-lg font-semibold text-foreground">
@@ -763,7 +771,10 @@ const FeedsPage = () => {
                 <span className="break-all text-xs text-muted-foreground">{feedPendingDeletion.url}</span>
               </div>
               {deleteFeedback ? (
-                <p className={buildFeedbackClassName(deleteFeedback)} role={buildFeedbackRole(deleteFeedback)}>
+                <p
+                  className={buildFeedbackClassName(deleteFeedback)}
+                  {...buildFeedbackAccessibilityProps(deleteFeedback)}
+                >
                   {deleteFeedback.message}
                 </p>
               ) : null}
@@ -785,7 +796,7 @@ const FeedsPage = () => {
                   {isDeleting ? t('feeds.list.deleting', 'Removendo...') : t('feeds.list.delete', 'Excluir')}
                 </button>
               </div>
-            </div>
+            </dialog>
           </div>,
           document.body,
         )
@@ -837,7 +848,10 @@ const FeedsPage = () => {
           </div>
         </form>
         {singleFeedback ? (
-          <p className={buildFeedbackClassName(singleFeedback)} role={buildFeedbackRole(singleFeedback)}>
+          <p
+            className={buildFeedbackClassName(singleFeedback)}
+            {...buildFeedbackAccessibilityProps(singleFeedback)}
+          >
             {singleFeedback.message}
           </p>
         ) : null}
@@ -871,7 +885,10 @@ const FeedsPage = () => {
           </div>
         </form>
         {bulkFeedback ? (
-          <p className={buildFeedbackClassName(bulkFeedback)} role={buildFeedbackRole(bulkFeedback)}>
+          <p
+            className={buildFeedbackClassName(bulkFeedback)}
+            {...buildFeedbackAccessibilityProps(bulkFeedback)}
+          >
             {bulkFeedback.message}
           </p>
         ) : null}
@@ -908,7 +925,10 @@ const FeedsPage = () => {
               <span className="text-xs text-muted-foreground">{t('feeds.list.syncing', 'Sincronizando...')}</span>
             ) : null}
             {listFeedback ? (
-              <p className={buildFeedbackClassName(listFeedback)} role={buildFeedbackRole(listFeedback)}>
+              <p
+                className={buildFeedbackClassName(listFeedback)}
+                {...buildFeedbackAccessibilityProps(listFeedback)}
+              >
                 {listFeedback.message}
               </p>
             ) : null}

--- a/frontend/src/pages/posts/PostsPage.tsx
+++ b/frontend/src/pages/posts/PostsPage.tsx
@@ -1186,7 +1186,9 @@ const PostsPage = () => {
       try {
         setIsRefreshRunning(true);
         setRefreshProgress(null);
-        void requestProgressUpdate();
+        requestProgressUpdate().catch((error) => {
+          console.error("Failed to request progress update", error);
+        });
 
         const refreshPromise = refreshPostsAsync();
         const cleanupPromise = cleanupPostsAsync();
@@ -1732,9 +1734,9 @@ const PostsPage = () => {
             </button>
           ) : null}
           {cooldownNotice ? (
-            <span className="text-xs text-warning" role="status">
+            <output className="text-xs text-warning" aria-live="polite" aria-atomic="true">
               {cooldownNotice}
-            </span>
+            </output>
           ) : cooldownMessage ? (
             <span className="text-xs text-muted-foreground">{cooldownMessage}</span>
           ) : null}
@@ -2061,12 +2063,13 @@ const PostsPage = () => {
 
       {isPreviewModalOpen && typeof document !== 'undefined'
         ? createPortal(
-            <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 px-4 py-6 backdrop-blur">
-              <div
-                role="dialog"
-                aria-modal="true"
+            <div className="fixed inset-0 z-50 flex items-center justify-center px-4 py-6">
+              <div className="fixed inset-0 bg-background/80 backdrop-blur" aria-hidden="true" />
+              <dialog
                 aria-labelledby="post-request-preview-title"
                 className="flex max-h-[90vh] w-full max-w-4xl flex-col gap-4 overflow-hidden rounded-lg border border-border bg-background p-6 shadow-lg"
+                aria-modal="true"
+                open
               >
                 <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                   <div className="space-y-2">
@@ -2335,7 +2338,7 @@ const PostsPage = () => {
                     </>
                   )}
                 </div>
-              </div>
+              </dialog>
             </div>,
             document.body,
           )
@@ -2582,16 +2585,16 @@ const PostListContent = ({
                 </div>
               ) : null}
               {copyFeedbacks[item.id] ? (
-                <p
-                  role="status"
+                <output
                   aria-live="polite"
+                  aria-atomic="true"
                   className={clsx(
                     'text-xs',
                     copyFeedbacks[item.id]?.type === 'success' ? 'text-primary' : 'text-danger',
                   )}
                 >
                   {copyFeedbacks[item.id]?.message}
-                </p>
+                </output>
               ) : null}
             </section>
             <section className="space-y-2">

--- a/frontend/src/pages/prompts/PromptsPage.tsx
+++ b/frontend/src/pages/prompts/PromptsPage.tsx
@@ -1810,7 +1810,7 @@ const PromptsPage = () => {
 
   return (
     <section className="space-y-6" aria-labelledby="prompts-heading">
-      <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+      <div className="sr-only" aria-live="polite" aria-atomic="true">
         {liveAnnouncement}
       </div>
       <header className="space-y-2">
@@ -1879,7 +1879,9 @@ const PromptsPage = () => {
 
       {feedback ? (
         <div
-          role={feedback.type === 'error' ? 'alert' : 'status'}
+          role={feedback.type === 'error' ? 'alert' : undefined}
+          aria-live={feedback.type === 'error' ? undefined : 'polite'}
+          aria-atomic={feedback.type === 'error' ? undefined : true}
           className={clsx(
             'rounded-md border px-4 py-3 text-sm',
             feedback.type === 'success'
@@ -1995,7 +1997,7 @@ const PromptsPage = () => {
       ) : null}
 
       {isLoading ? (
-        <div className="space-y-3" role="status" aria-live="polite">
+        <div className="space-y-3" aria-live="polite" aria-atomic="true">
           {loadingSkeletons.map((_, index) => (
             <div key={index} className="card space-y-3 p-4">
               <LoadingSkeleton className="h-5 w-3/4" />
@@ -2056,7 +2058,7 @@ const PromptsPage = () => {
                 </p>
               ) : null}
               {isReorderPending ? (
-                <p className="text-xs font-medium text-primary" role="status" aria-live="polite">
+                <p className="text-xs font-medium text-primary" aria-live="polite" aria-atomic="true">
                   {t('prompts.reorder.pending', 'Updating order...')}
                 </p>
               ) : null}
@@ -2090,48 +2092,50 @@ const PromptsPage = () => {
                     }}
                     className="relative max-h-[65vh] overflow-auto"
                     style={{ touchAction: 'pan-y' }}
-                    role="list"
                     aria-label={t('prompts.list.ariaLabel', 'Saved prompts')}
                   >
                     <div style={{ height: `${virtualizer.getTotalSize()}px`, position: 'relative' }}>
-                      {virtualizer.getVirtualItems().map((virtualItem) => {
-                        const prompt = orderedPrompts[virtualItem.index];
+                      <ul className="absolute inset-0 m-0 list-none p-0">
+                        {virtualizer.getVirtualItems().map((virtualItem) => {
+                          const prompt = orderedPrompts[virtualItem.index];
 
-                        if (!prompt) {
-                          return null;
-                        }
+                          if (!prompt) {
+                            return null;
+                          }
 
-                        const isLast = virtualItem.index === orderedPrompts.length - 1;
-                        const isActivePrompt = activeId === prompt.id;
+                          const isLast = virtualItem.index === orderedPrompts.length - 1;
+                          const isActivePrompt = activeId === prompt.id;
 
-                        return (
-                          <div
-                            key={virtualItem.key}
-                            className="absolute inset-x-0 pb-3"
-                            style={{
-                              transform: `translate3d(0, ${virtualItem.start}px, 0)`,
-                              willChange: 'transform',
-                            }}
-                            ref={(element) => {
-                              if (element) {
-                                virtualizer.measureElement(element);
-                              }
-                            }}
-                          >
-                            <SortablePromptCard
-                              prompt={prompt}
-                              canMoveUp={virtualItem.index > 0}
-                              canMoveDown={!isLast}
-                              onMoveUp={() => handleMovePrompt(prompt.id, 'up')}
-                              onMoveDown={() => handleMovePrompt(prompt.id, 'down')}
-                              isActive={isActivePrompt}
-                              showPlaceholder={isSorting && isActivePrompt}
-                              onKeyDown={(event) => handlePromptKeyDown(event, prompt)}
-                              isKeyboardActive={keyboardActiveId === prompt.id}
-                            />
-                          </div>
-                        );
-                      })}
+                          return (
+                            <li
+                              key={virtualItem.key}
+                              className="absolute inset-x-0"
+                              style={{
+                                transform: `translate3d(0, ${virtualItem.start}px, 0)`,
+                                willChange: 'transform',
+                              }}
+                              ref={(element) => {
+                                if (element) {
+                                  virtualizer.measureElement(element);
+                                }
+                              }}
+                            >
+                              <SortablePromptCard
+                                prompt={prompt}
+                                canMoveUp={virtualItem.index > 0}
+                                canMoveDown={!isLast}
+                                onMoveUp={() => handleMovePrompt(prompt.id, 'up')}
+                                onMoveDown={() => handleMovePrompt(prompt.id, 'down')}
+                                isActive={isActivePrompt}
+                                showPlaceholder={isSorting && isActivePrompt}
+                                onKeyDown={(event) => handlePromptKeyDown(event, prompt)}
+                                isKeyboardActive={keyboardActiveId === prompt.id}
+                              />
+                              {isLast ? null : <div className="h-3" aria-hidden="true" />}
+                            </li>
+                          );
+                        })}
+                      </ul>
                     </div>
                   </div>
                 ) : (
@@ -2141,29 +2145,29 @@ const PromptsPage = () => {
                     }}
                     className="relative max-h-[65vh] overflow-auto"
                     style={{ touchAction: 'pan-y' }}
-                    role="list"
                     aria-label={t('prompts.list.ariaLabel', 'Saved prompts')}
                   >
-                    <div className="space-y-3 pr-1">
+                    <ul className="space-y-3 pr-1">
                       {orderedPrompts.map((prompt, index) => {
                         const isActivePrompt = activeId === prompt.id;
 
                         return (
-                          <SortablePromptCard
-                            key={prompt.id}
-                            prompt={prompt}
-                            canMoveUp={index > 0}
-                            canMoveDown={index < orderedPrompts.length - 1}
-                            onMoveUp={() => handleMovePrompt(prompt.id, 'up')}
-                            onMoveDown={() => handleMovePrompt(prompt.id, 'down')}
-                            isActive={isActivePrompt}
-                            showPlaceholder={isSorting && isActivePrompt}
-                            onKeyDown={(event) => handlePromptKeyDown(event, prompt)}
-                            isKeyboardActive={keyboardActiveId === prompt.id}
-                          />
+                          <li key={prompt.id}>
+                            <SortablePromptCard
+                              prompt={prompt}
+                              canMoveUp={index > 0}
+                              canMoveDown={index < orderedPrompts.length - 1}
+                              onMoveUp={() => handleMovePrompt(prompt.id, 'up')}
+                              onMoveDown={() => handleMovePrompt(prompt.id, 'down')}
+                              isActive={isActivePrompt}
+                              showPlaceholder={isSorting && isActivePrompt}
+                              onKeyDown={(event) => handlePromptKeyDown(event, prompt)}
+                              isKeyboardActive={keyboardActiveId === prompt.id}
+                            />
+                          </li>
                         );
                       })}
-                    </div>
+                    </ul>
                   </div>
                 )}
               </SortableContext>
@@ -2202,12 +2206,13 @@ const PromptsPage = () => {
       ) : null}
       {isExportModalOpen && typeof document !== 'undefined'
         ? createPortal(
-            <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 px-4 py-6 backdrop-blur">
-              <div
-                role="dialog"
-                aria-modal="true"
+            <div className="fixed inset-0 z-50 flex items-center justify-center px-4 py-6">
+              <div className="fixed inset-0 bg-background/80 backdrop-blur" aria-hidden="true" />
+              <dialog
                 aria-labelledby="export-modal-title"
-                className="w-full max-w-2xl rounded-lg border border-border bg-background p-6 shadow-lg"
+                className="relative z-10 w-full max-w-2xl rounded-lg border border-border bg-background p-6 shadow-lg"
+                aria-modal="true"
+                open
               >
                 <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
                   <div className="space-y-1">
@@ -2271,7 +2276,7 @@ const PromptsPage = () => {
                     {t('prompts.export.copy', 'Copy')}
                   </button>
                 </div>
-              </div>
+              </dialog>
             </div>,
             document.body,
           )

--- a/frontend/src/pages/prompts/components/PromptCard.tsx
+++ b/frontend/src/pages/prompts/components/PromptCard.tsx
@@ -111,7 +111,6 @@ export const PromptCard = ({
     <div
       ref={assignRef}
       {...containerAttributes}
-      role="listitem"
       className={clsx(
         'relative card flex flex-col gap-4 p-4 outline-none transition-all duration-200 ease-out focus-visible:ring-2 focus-visible:ring-primary',
         'hover:shadow-sm',
@@ -122,12 +121,11 @@ export const PromptCard = ({
         isSorting ? 'transition-transform duration-200 ease-out' : '',
         !isEnabled ? 'border-dashed border-border/70 bg-muted/30' : '',
       )}
-      tabIndex={0}
       style={options?.style}
       data-dragging={isDragging}
       data-keyboard-grabbed={isKeyboardActive ? 'true' : undefined}
       aria-grabbed={isGrabbed}
-      onKeyDown={options?.onKeyDown}
+      onKeyDown={canReorder ? options?.onKeyDown : undefined}
     >
       {showPlaceholder ? (
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-lg bg-primary/5">


### PR DESCRIPTION
## Summary
- replace custom role-based modals in navigation, feeds, posts, and prompts with native dialog elements layered over an overlay backdrop
- reuse shared accessibility props for feed feedback messages and switch status messages to aria-live/output elements instead of role attributes
- render the prompts list with semantic list markup while keeping the sortable keyboard interactions intact

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e16464bc508325a4d3347ae18a0f9c