### PR TITLE
Fix frontend build type errors

### DIFF
--- a/frontend/src/app/routes/router.tsx
+++ b/frontend/src/app/routes/router.tsx
@@ -94,7 +94,6 @@ export const router = createBrowserRouter(
   ],
   {
     future: {
-      v7_startTransition: true,
       v7_relativeSplatPath: true,
     },
   },

--- a/frontend/src/pages/prompts/PromptsPage.tsx
+++ b/frontend/src/pages/prompts/PromptsPage.tsx
@@ -161,13 +161,10 @@ const PromptsPage = () => {
   const refetchPromptList = useCallback(() => {
     try {
       const result = promptList.refetch();
-      if (result && typeof (result as PromiseLike<unknown>).catch === 'function') {
-        return (result as PromiseLike<unknown>).catch((error) => {
-          console.error('[PromptsPage] Failed to refetch prompts', error);
-        });
-      }
-
-      return Promise.resolve(result);
+      return Promise.resolve(result).catch((error: unknown) => {
+        console.error('[PromptsPage] Failed to refetch prompts', error);
+        return undefined;
+      });
     } catch (error) {
       console.error('[PromptsPage] Failed to refetch prompts', error);
       return Promise.resolve(undefined);


### PR DESCRIPTION
## Summary
- remove the unsupported `v7_startTransition` future flag from the router setup
- wrap prompt list refetch calls in `Promise.resolve` to safely attach error logging

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e16cc7e9548325bd0a28935551031a