### PR TITLE
Improve confirmation dialogs across admin pages

### DIFF
--- a/frontend/src/components/dialogs/ConfirmDialog.tsx
+++ b/frontend/src/components/dialogs/ConfirmDialog.tsx
@@ -1,0 +1,94 @@
+import type { ReactNode } from 'react';
+import { useId } from 'react';
+import { createPortal } from 'react-dom';
+
+type ConfirmDialogProps = {
+  open: boolean;
+  title: string;
+  description?: string;
+  cancelLabel: string;
+  confirmLabel: string;
+  confirmLoadingLabel?: string;
+  confirmDisabled?: boolean;
+  cancelDisabled?: boolean;
+  destructive?: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+  children?: ReactNode;
+};
+
+export const ConfirmDialog = ({
+  open,
+  title,
+  description,
+  cancelLabel,
+  confirmLabel,
+  confirmLoadingLabel,
+  confirmDisabled = false,
+  cancelDisabled = false,
+  destructive = true,
+  onCancel,
+  onConfirm,
+  children,
+}: ConfirmDialogProps) => {
+  const titleId = useId();
+  const descriptionId = useId();
+
+  if (!open || typeof document === 'undefined') {
+    return null;
+  }
+
+  const confirmButtonClassName = destructive
+    ? 'inline-flex w-full items-center justify-center rounded-md border border-destructive px-4 py-2 text-sm font-medium text-destructive transition hover:bg-destructive hover:text-destructive-foreground disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto'
+    : 'inline-flex w-full items-center justify-center rounded-md border border-primary px-4 py-2 text-sm font-medium text-primary transition hover:bg-primary hover:text-primary-foreground disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto';
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center px-4 py-6">
+      <div className="fixed inset-0 bg-background/80 backdrop-blur" aria-hidden="true" />
+      <dialog
+        aria-labelledby={titleId}
+        aria-describedby={description ? descriptionId : undefined}
+        aria-modal="true"
+        className="relative z-10 w-full max-w-md rounded-lg border border-border bg-background p-6 shadow-lg"
+        open
+        role="dialog"
+      >
+        <div className="space-y-6">
+          <div className="space-y-2">
+            <h2 id={titleId} className="text-lg font-semibold text-foreground">
+              {title}
+            </h2>
+            {description ? (
+              <p id={descriptionId} className="text-sm text-muted-foreground">
+                {description}
+              </p>
+            ) : null}
+          </div>
+
+          {children ? <div className="space-y-3">{children}</div> : null}
+
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
+            <button
+              type="button"
+              className="inline-flex w-full items-center justify-center rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
+              onClick={onCancel}
+              disabled={cancelDisabled}
+            >
+              {cancelLabel}
+            </button>
+            <button
+              type="button"
+              className={confirmButtonClassName}
+              onClick={onConfirm}
+              disabled={confirmDisabled}
+            >
+              {confirmDisabled && confirmLoadingLabel ? confirmLoadingLabel : confirmLabel}
+            </button>
+          </div>
+        </div>
+      </dialog>
+    </div>,
+    document.body,
+  );
+};
+

--- a/frontend/src/pages/feeds/FeedsPage.test.tsx
+++ b/frontend/src/pages/feeds/FeedsPage.test.tsx
@@ -518,6 +518,9 @@ describe('FeedsPage', () => {
     const button = screen.getByRole('button', { name: /Resetar feeds \(admin\)/i });
     await user.click(button);
 
+    const dialog = await screen.findByRole('dialog', { name: /Resetar feeds/i });
+    await user.click(within(dialog).getByRole('button', { name: /Resetar feeds \(admin\)/i }));
+
     expect(resetMutateAsync).toHaveBeenCalled();
 
     const successMessage = i18n.t(
@@ -546,6 +549,9 @@ describe('FeedsPage', () => {
     const button = screen.getByRole('button', { name: /Resetar feeds \(admin\)/i });
     await user.click(button);
 
+    const dialog = await screen.findByRole('dialog', { name: /Resetar feeds/i });
+    await user.click(within(dialog).getByRole('button', { name: /Resetar feeds \(admin\)/i }));
+
     expect(resetMutateAsync).toHaveBeenCalled();
 
     const errorMessage = i18n.t(
@@ -553,7 +559,8 @@ describe('FeedsPage', () => {
       'Não foi possível concluir o reset. Tente novamente ou contate o administrador.',
     );
 
-    expect(await screen.findByText(errorMessage)).toBeInTheDocument();
+    const errorMessages = await screen.findAllByText(errorMessage);
+    expect(errorMessages.length).toBeGreaterThan(0);
   });
 });
 


### PR DESCRIPTION
## Summary
- add a reusable `ConfirmDialog` component for consistent modals
- replace window/browser confirmations in allowlist, feeds, and prompts pages with the new dialog
- update related unit tests to interact with the new confirmation flow

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68e173687c848325a6b641f55cc9d325