### PR TITLE
Refine prompts UI components

### DIFF
--- a/frontend/src/pages/prompts/PromptsPage.tsx
+++ b/frontend/src/pages/prompts/PromptsPage.tsx
@@ -512,13 +512,15 @@ const PromptsPage = () => {
       }
     };
 
-    window.addEventListener('pointermove', handlePointerMove);
-    window.addEventListener('resize', handleWindowResize);
+    const browserWindow = globalThis as Window & typeof globalThis;
+
+    browserWindow.addEventListener('pointermove', handlePointerMove);
+    browserWindow.addEventListener('resize', handleWindowResize);
     container.addEventListener('scroll', handleContainerScroll, { passive: true });
 
     return () => {
-      window.removeEventListener('pointermove', handlePointerMove);
-      window.removeEventListener('resize', handleWindowResize);
+      browserWindow.removeEventListener('pointermove', handlePointerMove);
+      browserWindow.removeEventListener('resize', handleWindowResize);
       container.removeEventListener('scroll', handleContainerScroll);
       listContainerBoundsRef.current = null;
     };
@@ -664,10 +666,12 @@ const PromptsPage = () => {
       }
     };
 
-    window.addEventListener('keydown', handleKeyDown);
+    const browserWindow = globalThis as Window & typeof globalThis;
+
+    browserWindow.addEventListener('keydown', handleKeyDown);
 
     return () => {
-      window.removeEventListener('keydown', handleKeyDown);
+      browserWindow.removeEventListener('keydown', handleKeyDown);
     };
   }, [isExportModalOpen]);
 


### PR DESCRIPTION
## Summary
- extract reusable hooks for mobile and settings menus to encapsulate event handling logic
- centralize authentication section rendering into a helper to simplify the TopNav component
- break the prompts management card into focused helpers to lower its cognitive complexity while preserving accessibility affordances
- replace window-specific event listener usage with globalThis in PromptsPage to satisfy cross-environment linting guidance

## Testing
- npm run lint (fails: existing lint errors in unrelated files)


------
https://chatgpt.com/codex/tasks/task_e_68e1827dd76c8325aebc0323903c0541