### PR TITLE
Fix timer ref types in PostsPage

### DIFF
--- a/frontend/src/pages/posts/PostsPage.tsx
+++ b/frontend/src/pages/posts/PostsPage.tsx
@@ -731,14 +731,18 @@ const PostsPage = () => {
   const [isOpenAiPrettyPrintEnabled, setIsOpenAiPrettyPrintEnabled] = useState(false);
   const [previewRequestSummary, setPreviewRequestSummary] = useState<PreviewRequestSummary | null>(null);
 
-  const cooldownNoticeTimeoutRef = useRef<number | null>(null);
-  const cooldownIntervalRef = useRef<number | null>(null);
+  const cooldownNoticeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cooldownIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const fetchStartTimeRef = useRef<number | null>(null);
   const previewRequestStartTimeRef = useRef<number | null>(null);
   const openAiPreviewControllerRef = useRef<AbortController | null>(null);
-  const refreshProgressIntervalRef = useRef<number | null>(null);
+  const refreshProgressIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const isProgressRequestInFlightRef = useRef(false);
-  const rateLimitBackoffRef = useRef<{ attempts: number; timeoutId: number | null; active: boolean }>({
+  const rateLimitBackoffRef = useRef<{
+    attempts: number;
+    timeoutId: ReturnType<typeof setTimeout> | null;
+    active: boolean;
+  }>({
     attempts: 0,
     timeoutId: null,
     active: false,


### PR DESCRIPTION
## Summary
- use ReturnType<typeof setTimeout> and ReturnType<typeof setInterval> for timer refs in PostsPage to avoid NodeJS.Timeout type mismatch
- adjust rate limit backoff metadata to store typed timeout handles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e194e6e5048325b9aae74817863764