### PR TITLE
Refine OpenAI probe error handling

### DIFF
--- a/backend/src/controllers/admin/news-generation.controller.js
+++ b/backend/src/controllers/admin/news-generation.controller.js
@@ -67,7 +67,7 @@ const previewOpenAI = asyncHandler(async (req, res, next) => {
 
     return res.status(200).json(rawResponse);
   } catch (error) {
-    if (error && typeof error === 'object' && 'status' in error && 'payloadBruto' in error) {
+    if (error instanceof postGenerationService.OpenAIResponseError) {
       const status = typeof error.status === 'number' ? error.status : 500;
       return res.status(status).json(error.payloadBruto ?? {});
     }

--- a/backend/src/controllers/posts.controller.js
+++ b/backend/src/controllers/posts.controller.js
@@ -35,12 +35,8 @@ const toIsoString = (value) => {
   if (value instanceof Date) {
     return Number.isNaN(value.valueOf()) ? null : value.toISOString();
   }
-  try {
-    const parsed = new Date(value);
-    return Number.isNaN(parsed.valueOf()) ? null : parsed.toISOString();
-  } catch (error) {
-    return null;
-  }
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.valueOf()) ? null : parsed.toISOString();
 };
 
 const mapPostListItem = (article, { includeDiagnostics = false } = {}) => {

--- a/backend/src/lib/openai-client.js
+++ b/backend/src/lib/openai-client.js
@@ -64,6 +64,7 @@ const createClient = ({ timeoutMs }) => {
               parsedPayload = await response.text();
             }
           } catch (parseError) {
+            console.warn('Failed to parse OpenAI error response payload', parseError);
             parsedPayload = null;
           }
 

--- a/backend/src/repositories/prompt.repository.js
+++ b/backend/src/repositories/prompt.repository.js
@@ -6,11 +6,12 @@ const defaultOrder = [{ position: 'asc' }, { createdAt: 'asc' }];
 
 const findManyByUser = async ({ userId, skip = 0, take, orderBy = defaultOrder, enabled }, client) => {
   const prismaClient = getClient(client);
+  const enabledFilter = enabled === undefined ? {} : { enabled };
 
   return prismaClient.prompt.findMany({
     where: {
       userId,
-      ...(enabled !== undefined ? { enabled } : {}),
+      ...enabledFilter,
     },
     orderBy,
     skip,
@@ -20,11 +21,12 @@ const findManyByUser = async ({ userId, skip = 0, take, orderBy = defaultOrder, 
 
 const countByUser = async ({ userId, enabled }, client) => {
   const prismaClient = getClient(client);
+  const enabledFilter = enabled === undefined ? {} : { enabled };
 
   return prismaClient.prompt.count({
     where: {
       userId,
-      ...(enabled !== undefined ? { enabled } : {}),
+      ...enabledFilter,
     },
   });
 };

--- a/backend/src/services/openai-diagnostics.service.js
+++ b/backend/src/services/openai-diagnostics.service.js
@@ -43,7 +43,9 @@ const extractErrorDetails = (error) => {
     }
   }
 
-  if (!details.message && error instanceof Error && typeof error.message === 'string') {
+  const isMessageMissing =
+    details.message === null || details.message === undefined || details.message === '';
+  if (isMessageMissing && error instanceof Error && typeof error.message === 'string') {
     details.message = error.message;
   }
 

--- a/backend/tests/post-generation.probe-openai.service.test.js
+++ b/backend/tests/post-generation.probe-openai.service.test.js
@@ -115,8 +115,15 @@ describe('postGenerationService.probeOpenAIResponse', () => {
 
     __mockClient.responses.create.mockRejectedValueOnce(error);
 
-    await expect(
-      postGenerationService.probeOpenAIResponse({ ownerKey, newsId: article.id }),
-    ).rejects.toEqual({ status: 429, payloadBruto: error.payload });
+    expect.assertions(3);
+
+    try {
+      await postGenerationService.probeOpenAIResponse({ ownerKey, newsId: article.id });
+      throw new Error('Expected probeOpenAIResponse to reject');
+    } catch (caughtError) {
+      expect(caughtError).toBeInstanceOf(postGenerationService.OpenAIResponseError);
+      expect(caughtError.status).toBe(429);
+      expect(caughtError.payloadBruto).toEqual(error.payload);
+    }
   });
 });

--- a/backend/tests/prompts.e2e.test.js
+++ b/backend/tests/prompts.e2e.test.js
@@ -244,7 +244,7 @@ describe('Prompts API', () => {
         .expect('Content-Type', /json/)
         .expect(200);
 
-      const lastPrompt = list.body.data.items[list.body.data.items.length - 1];
+      const lastPrompt = list.body.data.items.at(-1);
       expect(lastPrompt.id).toBe(first.id);
       expect(lastPrompt.enabled).toBe(false);
     });

--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -48,19 +48,19 @@ jest.mock('../src/lib/prisma', () => {
         return !matchesScalar(actual, condition.not);
       }
 
-      if (condition.gt !== undefined && !(actual > condition.gt)) {
+      if (condition.gt !== undefined && actual <= condition.gt) {
         return false;
       }
 
-      if (condition.gte !== undefined && !(actual >= condition.gte)) {
+      if (condition.gte !== undefined && actual < condition.gte) {
         return false;
       }
 
-      if (condition.lt !== undefined && !(actual < condition.lt)) {
+      if (condition.lt !== undefined && actual >= condition.lt) {
         return false;
       }
 
-      if (condition.lte !== undefined && !(actual <= condition.lte)) {
+      if (condition.lte !== undefined && actual > condition.lte) {
         return false;
       }
 
@@ -156,6 +156,22 @@ jest.mock('../src/lib/prisma', () => {
     return matchDateCondition(actual, expected);
   };
 
+  const matchesUrlCondition = (feed, urlCondition) => {
+    if (!urlCondition) {
+      return true;
+    }
+
+    if (Array.isArray(urlCondition.in)) {
+      return urlCondition.in.includes(feed.url);
+    }
+
+    if (typeof urlCondition === 'string') {
+      return feed.url === urlCondition;
+    }
+
+    return true;
+  };
+
   const matchFeedWhere = (feed, where = {}) => {
     if (where == null) {
       return true;
@@ -191,22 +207,6 @@ jest.mock('../src/lib/prisma', () => {
 
     return true;
   };
-
-  function matchesUrlCondition(feed, urlCondition) {
-    if (!urlCondition) {
-      return true;
-    }
-
-    if (Array.isArray(urlCondition.in)) {
-      return urlCondition.in.includes(feed.url);
-    }
-
-    if (typeof urlCondition === 'string') {
-      return feed.url === urlCondition;
-    }
-
-    return true;
-  }
 
   function matchesLogicalGroup(feed, conditions, predicate) {
     if (!Array.isArray(conditions) || conditions.length === 0) {


### PR DESCRIPTION
## Summary
- replace negated filters in prompt repository queries and adjust post generation previews to validate IDs explicitly
- improve OpenAI diagnostics fallback messaging and error payload logging to satisfy minor SonarCloud rules
- update backend tests to use Array.prototype.at and simplify comparison helpers
- wrap OpenAI probe failures in a dedicated error class surfaced to the admin controller
- hoist the mocked Prisma feed URL matcher to module scope to satisfy SonarCloud nesting guidance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e199bcef3883258de822acddcda56a