### PR TITLE
Fix prompt toggle accessibility

### DIFF
--- a/frontend/src/pages/prompts/components/PromptCard.tsx
+++ b/frontend/src/pages/prompts/components/PromptCard.tsx
@@ -408,7 +408,8 @@ const PromptSideControls = ({
   <div className="flex flex-col items-stretch gap-3 sm:items-end">
     <button
       type="button"
-      aria-pressed={isEnabled}
+      role="switch"
+      aria-checked={isEnabled}
       aria-label={toggleAriaLabel}
       onClick={onToggleEnabled}
       disabled={isTogglePending}


### PR DESCRIPTION
## Summary
- expose the prompt enable toggle as an ARIA switch so assistive tech can read the state correctly

## Testing
- npm test -- src/pages/prompts/PromptsPage.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e1bf83f31c8325a91a6aef2186c0f3