### PR TITLE
Fix typing for post list diagnostics logging

### DIFF
--- a/frontend/src/pages/posts/PostsPage.tsx
+++ b/frontend/src/pages/posts/PostsPage.tsx
@@ -1,11 +1,13 @@
 import type { ChangeEvent, Dispatch, JSX, MutableRefObject, SetStateAction } from 'react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { UseQueryResult } from '@tanstack/react-query';
 import { createPortal } from 'react-dom';
 import * as Sentry from '@sentry/react';
 import { useTranslation } from 'react-i18next';
 import { clsx } from 'clsx';
 
 import { useCleanupPosts, usePostList, useRefreshPosts } from '@/features/posts/hooks/usePosts';
+import type { PostListResponse } from '@/features/posts/api/posts';
 import type {
   CleanupResult,
   PostGenerationProgress,
@@ -970,7 +972,7 @@ const handlePostListFetchEffect = ({
   recordFetchSuccess,
   listWindowDays,
 }: {
-  postListQuery: ReturnType<typeof usePostList>;
+  postListQuery: UseQueryResult<PostListResponse, HttpError>;
   fetchStartTimeRef: MutableRefObject<number | null>;
   recordFetchSuccess: (duration: number) => void;
   listWindowDays: number;


### PR DESCRIPTION
## Summary
- ensure the posts fetch diagnostics handler uses a correctly typed query result
- record the PostListResponse type so Sentry breadcrumb logging can safely access items

## Testing
- env CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1d581c4a8832581c5a17d363faeca