### PR TITLE
Add unit tests for HTML diagnostics and TTL cache utilities

### DIFF
--- a/backend/tests/utils/html-diagnostics.test.js
+++ b/backend/tests/utils/html-diagnostics.test.js
@@ -1,0 +1,65 @@
+const {
+  hasBlockTags,
+  looksEscapedHtml,
+  computeWeakContent,
+  buildPreview,
+} = require('../../src/utils/html-diagnostics');
+
+describe('html-diagnostics utilities', () => {
+  describe('hasBlockTags', () => {
+    it('detects known block level tags', () => {
+      expect(hasBlockTags('<p>conteúdo</p>')).toBe(true);
+      expect(hasBlockTags('<span>inline</span>')).toBe(false);
+    });
+  });
+
+  describe('looksEscapedHtml', () => {
+    it('detects escaped block tags', () => {
+      expect(looksEscapedHtml('&lt;div&gt;texto&lt;/div&gt;')).toBe(true);
+      expect(looksEscapedHtml('&lt;span&gt;inline&lt;/span&gt;')).toBe(false);
+    });
+  });
+
+  describe('computeWeakContent', () => {
+    it('marks content without block tags as weak even when long', () => {
+      const longInline = 'palavra '.repeat(100);
+
+      const result = computeWeakContent({ html: `<span>${longInline}</span>` });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          containsBlocks: false,
+          weak: true,
+        }),
+      );
+    });
+
+    it('considers content with block tags and enough length as strong', () => {
+      const paragraph = `<p>${'conteúdo '.repeat(40)}</p>`;
+
+      const result = computeWeakContent({ html: paragraph });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          containsBlocks: true,
+          weak: false,
+        }),
+      );
+    });
+  });
+
+  describe('buildPreview', () => {
+    it('returns original content when shorter than limit', () => {
+      expect(buildPreview('resumo', 10)).toBe('resumo');
+    });
+
+    it('truncates strings that exceed the maximum length', () => {
+      expect(buildPreview('0123456789', 5)).toBe('01234');
+    });
+
+    it('returns empty string for invalid input', () => {
+      expect(buildPreview(null, 100)).toBe('');
+      expect(buildPreview('content', 0)).toBe('');
+    });
+  });
+});

--- a/backend/tests/utils/ttl-cache.test.js
+++ b/backend/tests/utils/ttl-cache.test.js
@@ -1,0 +1,72 @@
+const { createTtlCache } = require('../../src/utils/ttl-cache');
+
+describe('createTtlCache', () => {
+  const initialTime = new Date('2024-01-01T00:00:00Z');
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(initialTime);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('stores and retrieves values while entries are valid', () => {
+    const cache = createTtlCache({ ttlMs: 1_000 });
+
+    cache.set('key', 'value');
+
+    expect(cache.get('key')).toBe('value');
+  });
+
+  it('expires entries based on the provided ttl', () => {
+    const cache = createTtlCache({ ttlMs: 1_000 });
+
+    cache.set('expiring', 'value');
+
+    jest.advanceTimersByTime(999);
+    expect(cache.get('expiring')).toBe('value');
+
+    jest.advanceTimersByTime(1);
+    expect(cache.get('expiring')).toBeUndefined();
+  });
+
+  it('supports custom ttl per entry', () => {
+    const cache = createTtlCache({ ttlMs: 10_000 });
+
+    cache.set('short', 'value', 500);
+    cache.set('long', 'value', 2_000);
+
+    jest.advanceTimersByTime(600);
+
+    expect(cache.get('short')).toBeUndefined();
+    expect(cache.get('long')).toBe('value');
+  });
+
+  it('prunes expired entries when requested', () => {
+    const cache = createTtlCache({ ttlMs: 500 });
+
+    cache.set('a', 'value-a');
+    jest.advanceTimersByTime(600);
+
+    cache.prune();
+
+    expect(cache.get('a')).toBeUndefined();
+  });
+
+  it('enforces maximum capacity by removing the oldest entries first', () => {
+    const cache = createTtlCache({ ttlMs: 5_000, maxEntries: 2 });
+
+    cache.set('first', 'one', 1_000);
+    cache.set('second', 'two', 2_000);
+
+    jest.advanceTimersByTime(100);
+
+    cache.set('third', 'three', 3_000);
+
+    expect(cache.get('first')).toBeUndefined();
+    expect(cache.get('second')).toBe('two');
+    expect(cache.get('third')).toBe('three');
+  });
+});


### PR DESCRIPTION
## Summary
- add dedicated unit tests to cover html diagnostic helpers
- add coverage for ttl cache operations including expiry and capacity handling

## Testing
- npm test -- utils/html-diagnostics.test.js utils/ttl-cache.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2630b587c8325abaae37e6e38c8d4