### PR TITLE
Update Swagger docs for admin endpoints

### DIFF
--- a/backend/src/docs/openapi.js
+++ b/backend/src/docs/openapi.js
@@ -515,6 +515,89 @@ const definition = {
           },
         },
       },
+      PostPreviewArticle: {
+        type: 'object',
+        properties: {
+          id: { type: 'integer', example: 1 },
+          title: { type: ['string', 'null'], example: 'Notícia exemplo' },
+          contentSnippet: {
+            type: ['string', 'null'],
+            example: 'Resumo breve da notícia selecionada.',
+          },
+          articleHtml: {
+            type: ['string', 'null'],
+            example: '<p>Conteúdo completo da notícia</p>',
+          },
+          link: { type: ['string', 'null'], format: 'uri', example: 'https://example.com/noticia' },
+          guid: { type: ['string', 'null'], example: 'guid-1' },
+          publishedAt: {
+            type: ['string', 'null'],
+            format: 'date-time',
+            example: '2025-01-20T12:00:00.000Z',
+          },
+          feed: {
+            type: ['object', 'null'],
+            allOf: [{ $ref: '#/components/schemas/PostFeedReference' }],
+            example: { id: 1, title: 'Feed principal', url: 'https://example.com/rss.xml' },
+          },
+        },
+      },
+      PostPreviewMessageContent: {
+        type: 'object',
+        properties: {
+          type: { type: 'string', example: 'input_text' },
+          text: {
+            type: 'string',
+            example:
+              'Notícia ID interno: 1\nFeed: Feed principal · URL: https://example.com/rss.xml\nTítulo: Notícia exemplo',
+          },
+        },
+      },
+      PostPreviewMessage: {
+        type: 'object',
+        properties: {
+          role: { type: 'string', example: 'user' },
+          content: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/PostPreviewMessageContent' },
+          },
+        },
+      },
+      PostPreviewPayload: {
+        type: 'object',
+        properties: {
+          article: { $ref: '#/components/schemas/PostPreviewArticle' },
+          message: { $ref: '#/components/schemas/PostPreviewMessage' },
+          context: {
+            type: 'string',
+            example:
+              'Notícia ID interno: 1\nFeed: Feed principal · URL: https://example.com/rss.xml\nTítulo: Notícia exemplo',
+          },
+        },
+      },
+      PostRequestPreview: {
+        type: 'object',
+        properties: {
+          prompt_base: {
+            type: 'string',
+            example:
+              'Titulo A\n\nConteudo A\n\nInstrução final: gerar um post para LinkedIn com base na notícia e no contexto acima.',
+          },
+          prompt_base_hash: {
+            type: ['string', 'null'],
+            example: 'e3b0c44298fc1c149afbf4c8996fb924',
+          },
+          model: { type: 'string', example: 'gpt-5-nano' },
+          news_payload: {
+            oneOf: [
+              { $ref: '#/components/schemas/PostPreviewPayload' },
+              { type: 'null' },
+            ],
+            description:
+              'Estrutura com artigo normalizado, mensagem e contexto que seriam enviados para a OpenAI. Nulo quando nenhuma notícia elegível é encontrada.',
+          },
+        },
+      },
       PostContent: {
         type: 'object',
         properties: {
@@ -588,6 +671,75 @@ const definition = {
           items: {
             type: 'array',
             items: { $ref: '#/components/schemas/PostListItem' },
+          },
+        },
+      },
+      AdminGenerationTriggerResult: {
+        type: 'object',
+        properties: {
+          ownerKey: { type: 'string', example: '1' },
+          summary: {
+            $ref: '#/components/schemas/PostGenerationSummary',
+          },
+        },
+      },
+      AdminGenerationStatusResult: {
+        type: 'object',
+        properties: {
+          ownerKey: { type: 'string', example: '1' },
+          status: {
+            oneOf: [
+              { $ref: '#/components/schemas/PostGenerationProgress' },
+              { type: 'null' },
+            ],
+            description: 'Último status conhecido da geração manual para o usuário.',
+          },
+        },
+      },
+      OpenAiDiagnosticsResult: {
+        type: 'object',
+        properties: {
+          ok: { type: 'boolean', example: true },
+          model: { type: 'string', example: 'gpt-5-nano' },
+          baseURL: {
+            type: ['string', 'null'],
+            format: 'uri',
+            example: 'https://api.openai.com/v1',
+          },
+          timeoutMs: { type: 'integer', example: 30000 },
+          latencyMs: { type: 'integer', example: 850 },
+          usage: {
+            type: ['object', 'null'],
+            description: 'Informações de uso retornadas pela Responses API.',
+            example: {
+              total_tokens: 24,
+              input_tokens: 12,
+              output_tokens: 12,
+            },
+          },
+          cachedTokens: { type: ['integer', 'null'], example: 1200 },
+          error: {
+            type: ['object', 'null'],
+            properties: {
+              status: { type: ['integer', 'null'], example: 401 },
+              type: { type: ['string', 'null'], example: 'invalid_request_error' },
+              code: { type: ['string', 'null'], example: 'invalid_api_key' },
+              message: {
+                type: ['string', 'null'],
+                example: 'Invalid API key provided',
+              },
+              request_id: {
+                type: ['string', 'null'],
+                example: 'req_abc123',
+              },
+            },
+            example: {
+              status: 401,
+              type: 'invalid_request_error',
+              code: 'invalid_api_key',
+              message: 'Invalid API key provided',
+              request_id: 'req_abc123',
+            },
           },
         },
       },

--- a/backend/src/routes/v1/admin/news.routes.js
+++ b/backend/src/routes/v1/admin/news.routes.js
@@ -5,13 +5,250 @@ const { previewPayloadQuerySchema } = require('../../../schemas/news.schema');
 
 const router = express.Router();
 
+/**
+ * @openapi
+ * /api/v1/admin/news/generate-posts:
+ *   post:
+ *     summary: Trigger manual post generation for the authenticated owner
+ *     description: Inicia imediatamente a geração de posts para as notícias elegíveis do usuário autenticado.
+ *     tags:
+ *       - Admin - News Generation
+ *     security:
+ *       - SessionCookie: []
+ *       - BearerAuth: []
+ *     responses:
+ *       '200':
+ *         description: Geração executada com sucesso ou já em andamento.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Envelope'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       $ref: '#/components/schemas/AdminGenerationTriggerResult'
+ *             examples:
+ *               success:
+ *                 value:
+ *                   success: true
+ *                   data:
+ *                     ownerKey: '1'
+ *                     summary:
+ *                       ownerKey: '1'
+ *                       startedAt: '2025-01-20T12:34:56.000Z'
+ *                       finishedAt: '2025-01-20T12:35:45.000Z'
+ *                       eligibleCount: 3
+ *                       generatedCount: 2
+ *                       failedCount: 1
+ *                       skippedCount: 0
+ *                       promptBaseHash: e3b0c44298fc1c149afbf4c8996fb924
+ *                       modelUsed: gpt-5-nano
+ *                       errors:
+ *                         - articleId: 42
+ *                           reason: OpenAI request timed out
+ *                   meta:
+ *                     requestId: 00000000-0000-4000-8000-000000000000
+ *       '401':
+ *         $ref: '#/components/responses/Unauthorized'
+ *       '403':
+ *         $ref: '#/components/responses/Forbidden'
+ */
 router.post('/generate-posts', newsGenerationController.triggerGeneration);
+
+/**
+ * @openapi
+ * /api/v1/admin/news/generation-status:
+ *   get:
+ *     summary: Retrieve the latest manual generation status
+ *     description: Retorna o progresso mais recente da geração manual de posts iniciada via endpoint administrativo.
+ *     tags:
+ *       - Admin - News Generation
+ *     security:
+ *       - SessionCookie: []
+ *       - BearerAuth: []
+ *     responses:
+ *       '200':
+ *         description: Status atual (ou nulo) da última execução manual.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Envelope'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       $ref: '#/components/schemas/AdminGenerationStatusResult'
+ *             examples:
+ *               running:
+ *                 value:
+ *                   success: true
+ *                   data:
+ *                     ownerKey: '1'
+ *                     status:
+ *                       ownerKey: '1'
+ *                       startedAt: '2025-01-20T12:34:56.000Z'
+ *                       updatedAt: '2025-01-20T12:35:10.000Z'
+ *                       finishedAt: null
+ *                       status: in_progress
+ *                       phase: generating_posts
+ *                       message: 'Gerando post 2 de 5...'
+ *                       eligibleCount: 5
+ *                       processedCount: 1
+ *                       generatedCount: 1
+ *                       failedCount: 0
+ *                       skippedCount: 0
+ *                       currentArticleId: 42
+ *                       currentArticleTitle: 'Exemplo de notícia'
+ *                       promptBaseHash: e3b0c44298fc1c149afbf4c8996fb924
+ *                       modelUsed: gpt-5-nano
+ *                       errors: []
+ *                   meta:
+ *                     requestId: 11111111-2222-4333-8444-555555555555
+ *       '401':
+ *         $ref: '#/components/responses/Unauthorized'
+ *       '403':
+ *         $ref: '#/components/responses/Forbidden'
+ */
 router.get('/generation-status', newsGenerationController.getStatus);
+
+/**
+ * @openapi
+ * /api/v1/admin/news/preview-payload:
+ *   get:
+ *     summary: Preview the payload that would be sent to OpenAI
+ *     description: Monta o prompt concatenado e o payload de notícia que seria enviado para a OpenAI durante a geração manual.
+ *     tags:
+ *       - Admin - News Generation
+ *     security:
+ *       - SessionCookie: []
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: news_id
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *         description: ID da notícia a ser inspecionada. Quando omitido, utiliza a próxima notícia elegível.
+ *     responses:
+ *       '200':
+ *         description: Preview construído com sucesso.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Envelope'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       $ref: '#/components/schemas/PostRequestPreview'
+ *             examples:
+ *               success:
+ *                 value:
+ *                   success: true
+ *                   data:
+ *                     prompt_base: |-
+ *                       Titulo A
+ *
+ *                       Conteudo A
+ *
+ *                       Instrução final: gerar um post para LinkedIn com base na notícia e no contexto acima.
+ *                     prompt_base_hash: e3b0c44298fc1c149afbf4c8996fb924
+ *                     model: gpt-5-nano
+ *                     news_payload:
+ *                       article:
+ *                         id: 1
+ *                         title: Notícia exemplo
+ *                         contentSnippet: Resumo da notícia
+ *                         articleHtml: '<p>Notícia</p>'
+ *                         link: https://example.com/noticia
+ *                         guid: guid-1
+ *                         publishedAt: '2025-01-20T12:00:00.000Z'
+ *                         feed:
+ *                           id: 1
+ *                           title: Feed principal
+ *                           url: https://example.com/rss.xml
+ *                       message:
+ *                         role: user
+ *                         content:
+ *                           - type: input_text
+ *                             text: |-
+ *                               Notícia ID interno: 1
+ *                               Feed: Feed principal · URL: https://example.com/rss.xml
+ *                               Título: Notícia exemplo
+ *                               Publicado em: 2025-01-20T12:00:00.000Z
+ *                               Resumo: Resumo da notícia
+ *       '400':
+ *         $ref: '#/components/responses/BadRequest'
+ *       '401':
+ *         $ref: '#/components/responses/Unauthorized'
+ *       '403':
+ *         $ref: '#/components/responses/Forbidden'
+ *       '404':
+ *         $ref: '#/components/responses/NotFound'
+ */
 router.get(
   '/preview-payload',
   validateRequest({ query: previewPayloadQuerySchema }),
   newsGenerationController.previewPayload,
 );
+
+/**
+ * @openapi
+ * /api/v1/admin/news/preview-openai:
+ *   get:
+ *     summary: Execute the OpenAI probe with the current configuration
+ *     description: Executa uma chamada direta para a OpenAI Responses API e retorna a resposta bruta para inspeção.
+ *     tags:
+ *       - Admin - News Generation
+ *     security:
+ *       - SessionCookie: []
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: news_id
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *         description: ID da notícia alvo. Quando ausente, utiliza a próxima notícia elegível.
+ *     responses:
+ *       '200':
+ *         description: Resposta retornada pela OpenAI.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               description: Estrutura original devolvida pela Responses API da OpenAI.
+ *             examples:
+ *               openaiResponse:
+ *                 value:
+ *                   id: resp_1234567890
+ *                   model: gpt-5-nano
+ *                   created: 1737136800
+ *                   response:
+ *                     - role: assistant
+ *                       content:
+ *                         - type: output_text
+ *                           text: 'Exemplo de post gerado.'
+ *                   usage:
+ *                     total_tokens: 240
+ *                     input_tokens: 160
+ *                     output_tokens: 80
+ *       '400':
+ *         $ref: '#/components/responses/BadRequest'
+ *       '401':
+ *         $ref: '#/components/responses/Unauthorized'
+ *       '403':
+ *         $ref: '#/components/responses/Forbidden'
+ *       '404':
+ *         $ref: '#/components/responses/NotFound'
+ *       default:
+ *         description: Erro propagado diretamente pela OpenAI.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ */
 router.get(
   '/preview-openai',
   validateRequest({ query: previewPayloadQuerySchema }),

--- a/backend/src/routes/v1/admin/openai.routes.js
+++ b/backend/src/routes/v1/admin/openai.routes.js
@@ -3,6 +3,69 @@ const openAiController = require('../../../controllers/admin/openai.controller')
 
 const router = express.Router();
 
+/**
+ * @openapi
+ * /api/v1/admin/openai/diag:
+ *   get:
+ *     summary: Run a connectivity diagnostic against the OpenAI Responses API
+ *     description: Executa uma chamada mínima para a OpenAI Responses API e retorna métricas de latência e eventuais erros.
+ *     tags:
+ *       - Admin - OpenAI
+ *     security:
+ *       - SessionCookie: []
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: model
+ *         schema:
+ *           type: string
+ *         description: Modelo OpenAI opcional a ser utilizado no diagnóstico. Quando ausente, usa o modelo configurado na aplicação.
+ *     responses:
+ *       '200':
+ *         description: Resultado da execução do diagnóstico.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Envelope'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       $ref: '#/components/schemas/OpenAiDiagnosticsResult'
+ *             examples:
+ *               success:
+ *                 value:
+ *                   success: true
+ *                   data:
+ *                     ok: true
+ *                     model: gpt-5-nano
+ *                     baseURL: https://api.openai.com/v1
+ *                     timeoutMs: 30000
+ *                     latencyMs: 842
+ *                     usage:
+ *                       total_tokens: 24
+ *                       input_tokens: 12
+ *                       output_tokens: 12
+ *               failure:
+ *                 value:
+ *                   success: true
+ *                   data:
+ *                     ok: false
+ *                     model: gpt-5-nano
+ *                     baseURL: https://api.openai.com/v1
+ *                     timeoutMs: 30000
+ *                     latencyMs: 120
+ *                     error:
+ *                       status: 401
+ *                       type: invalid_request_error
+ *                       code: invalid_api_key
+ *                       message: Invalid API key provided
+ *                       request_id: req_abc123
+ *       '401':
+ *         $ref: '#/components/responses/Unauthorized'
+ *       '403':
+ *         $ref: '#/components/responses/Forbidden'
+ */
 router.get('/diag', openAiController.runDiagnostics);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- document the admin news generation endpoints with Swagger annotations and detailed response examples
- add diagnostics documentation for the admin OpenAI route and reuse it in the OpenAPI components
- extend the OpenAPI schema definitions to cover preview payloads and admin generation responses used by the new docs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e262ddf254832584508180a184085e