### PR TITLE
Fix SonarCloud warnings in prompts UI and cache tests

### DIFF
--- a/backend/tests/utils/ttl-cache.test.js
+++ b/backend/tests/utils/ttl-cache.test.js
@@ -13,7 +13,7 @@ describe('createTtlCache', () => {
   });
 
   it('stores and retrieves values while entries are valid', () => {
-    const cache = createTtlCache({ ttlMs: 1_000 });
+    const cache = createTtlCache({ ttlMs: 1000 });
 
     cache.set('key', 'value');
 
@@ -21,7 +21,7 @@ describe('createTtlCache', () => {
   });
 
   it('expires entries based on the provided ttl', () => {
-    const cache = createTtlCache({ ttlMs: 1_000 });
+    const cache = createTtlCache({ ttlMs: 1000 });
 
     cache.set('expiring', 'value');
 
@@ -33,10 +33,10 @@ describe('createTtlCache', () => {
   });
 
   it('supports custom ttl per entry', () => {
-    const cache = createTtlCache({ ttlMs: 10_000 });
+    const cache = createTtlCache({ ttlMs: 10000 });
 
     cache.set('short', 'value', 500);
-    cache.set('long', 'value', 2_000);
+    cache.set('long', 'value', 2000);
 
     jest.advanceTimersByTime(600);
 
@@ -56,14 +56,14 @@ describe('createTtlCache', () => {
   });
 
   it('enforces maximum capacity by removing the oldest entries first', () => {
-    const cache = createTtlCache({ ttlMs: 5_000, maxEntries: 2 });
+    const cache = createTtlCache({ ttlMs: 5000, maxEntries: 2 });
 
-    cache.set('first', 'one', 1_000);
-    cache.set('second', 'two', 2_000);
+    cache.set('first', 'one', 1000);
+    cache.set('second', 'two', 2000);
 
     jest.advanceTimersByTime(100);
 
-    cache.set('third', 'three', 3_000);
+    cache.set('third', 'three', 3000);
 
     expect(cache.get('first')).toBeUndefined();
     expect(cache.get('second')).toBe('two');

--- a/frontend/src/pages/prompts/components/PromptCard.tsx
+++ b/frontend/src/pages/prompts/components/PromptCard.tsx
@@ -91,12 +91,15 @@ const resolveReorderConfig = (
   options: PromptCardRenderOptions | undefined,
   canReorder: boolean,
 ): PromptReorderConfig => {
-  const containerAttributes: Partial<DraggableAttributes> = options?.containerAttributes ?? {};
-  const { role, tabIndex, onKeyDown, ...restContainerAttributes } = containerAttributes as {
-    role?: string;
-    tabIndex?: number;
-    onKeyDown?: PromptCardRenderOptions['onKeyDown'];
-  };
+  const containerAttributes = options?.containerAttributes as
+    | (Partial<DraggableAttributes> & {
+        role?: string;
+        tabIndex?: number;
+        onKeyDown?: PromptCardRenderOptions['onKeyDown'];
+      })
+    | undefined;
+
+  const { role, tabIndex, onKeyDown, ...restContainerAttributes } = containerAttributes ?? {};
   const isOverlay = options?.isOverlay ?? false;
   const isDragging = options?.isDragging ?? false;
   const isSorting = options?.isSorting ?? false;
@@ -105,14 +108,33 @@ const resolveReorderConfig = (
   const handleListeners =
     canReorder && options?.handleListeners ? options.handleListeners : EMPTY_SYNTHETIC_LISTENERS;
 
+  type HandleAttributes = Partial<DraggableAttributes> & {
+    role?: string;
+    tabIndex?: number;
+    onKeyDown?: PromptCardRenderOptions['onKeyDown'];
+  };
+
+  const handleAttributes: HandleAttributes = {};
+
+  if (role !== undefined) {
+    handleAttributes.role = role;
+  }
+
+  if (tabIndex !== undefined) {
+    handleAttributes.tabIndex = tabIndex;
+  }
+
+  if (onKeyDown !== undefined) {
+    handleAttributes.onKeyDown = onKeyDown;
+  }
+
+  if (options?.handleAttributes) {
+    Object.assign(handleAttributes, options.handleAttributes);
+  }
+
   return {
     containerAttributes: restContainerAttributes,
-    handleAttributes: {
-      ...(role !== undefined || tabIndex !== undefined || onKeyDown !== undefined
-        ? { role, tabIndex, onKeyDown }
-        : {}),
-      ...(options?.handleAttributes ?? {}),
-    },
+    handleAttributes,
     handleListeners,
     showPlaceholder: Boolean(options?.showPlaceholder && !isOverlay),
     isDragging,


### PR DESCRIPTION
## Summary
- add a helper to refetch the prompt list without using the void operator and reuse it where needed
- avoid spreading empty objects when toggling prompt overrides and when building drag handle attributes
- replace numeric separators in ttl-cache tests to address SonarCloud parsing warnings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2668a31e083259753651e7f4e496c