### PR TITLE
feat: support manual post generation

### DIFF
--- a/backend/src/routes/v1/posts.routes.js
+++ b/backend/src/routes/v1/posts.routes.js
@@ -12,8 +12,8 @@ const router = express.Router();
  * @openapi
  * /api/v1/posts/refresh:
  *   post:
- *     summary: Refresh articles and generate posts from configured feeds
- *     description: Consulta todos os feeds do usuário autenticado, aplica a janela de retenção configurada e aciona a geração de posts para notícias recentes utilizando os prompts habilitados.
+ *     summary: Refresh articles from configured feeds
+ *     description: Consulta todos os feeds do usuário autenticado, aplica a janela de retenção configurada e atualiza as notícias recentes disponíveis para geração manual de posts.
  *     tags:
  *       - Posts
  *     security:
@@ -61,23 +61,85 @@ const router = express.Router();
  *                         invalidItems: 0
  *                         error:
  *                           message: Feed request timed out
- *                     generation:
- *                       ownerKey: '1'
- *                       startedAt: '2025-01-20T12:34:56.000Z'
- *                       finishedAt: '2025-01-20T12:34:57.000Z'
- *                       eligibleCount: 2
- *                       generatedCount: 2
- *                       failedCount: 0
- *                       skippedCount: 1
- *                       promptBaseHash: 'e3b0c44298fc1c149afbf4c8996fb924'
- *                       modelUsed: gpt-5-nano
- *                       errors: null
+ *                     generation: null
  *                   meta:
  *                     requestId: 77777777-8888-4999-8aaa-bbbbbbbbbbbb
  *       '401':
  *         $ref: '#/components/responses/Unauthorized'
  */
 router.post('/posts/refresh', postsController.refresh);
+
+/**
+ * @openapi
+ * /api/v1/posts/{articleId}/generate:
+ *   post:
+ *     summary: Generate a LinkedIn post for a specific article
+ *     description: Gera manualmente um post do LinkedIn para a notícia informada utilizando os prompts configurados.
+ *     tags:
+ *       - Posts
+ *     security:
+ *       - SessionCookie: []
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: articleId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     responses:
+ *       '200':
+ *         description: Post gerado com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/Envelope'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       type: object
+ *                       properties:
+ *                         item:
+ *                           $ref: '#/components/schemas/PostListItem'
+ *                         cacheInfo:
+ *                           type: object
+ *                           nullable: true
+ *                           properties:
+ *                             cachedTokens:
+ *                               type: integer
+ *                               nullable: true
+ *                         reused:
+ *                           type: boolean
+ *             examples:
+ *               success:
+ *                 value:
+ *                   success: true
+ *                   data:
+ *                     item:
+ *                       id: 1
+ *                       title: 'Example article'
+ *                       contentSnippet: 'Resumo da notícia'
+ *                       publishedAt: '2025-01-20T12:34:56.000Z'
+ *                       feed:
+ *                         id: 2
+ *                         title: 'Feed'
+ *                         url: 'https://example.com/rss'
+ *                       post:
+ *                         content: 'Post gerado manualmente.'
+ *                         status: SUCCESS
+ *                         generatedAt: '2025-01-20T12:35:10.000Z'
+ *                         attemptCount: 1
+ *                     cacheInfo: null
+ *                     reused: false
+ *       '400':
+ *         $ref: '#/components/responses/BadRequest'
+ *       '401':
+ *         $ref: '#/components/responses/Unauthorized'
+ *       '404':
+ *         $ref: '#/components/responses/NotFound'
+ */
+router.post('/posts/:articleId/generate', postsController.generateForArticle);
 
 /**
  * @openapi

--- a/frontend/src/config/i18n.ts
+++ b/frontend/src/config/i18n.ts
@@ -357,6 +357,11 @@ const resources = {
             article: 'NEWS',
           },
           copyPost: 'Copy post',
+          postNotGenerated: 'Post not generated yet.',
+          generatePost: 'Generate post',
+          generatingPost: 'Generating post...',
+          generateSuccess: 'Post generated successfully.',
+          generateReused: 'Post was already generated.',
           postUnavailable: 'Post not available yet.',
           article: {
             readMore: 'See more',
@@ -885,6 +890,11 @@ const resources = {
             article: 'NOTICIA',
           },
           copyPost: 'Copiar post',
+          postNotGenerated: 'POST nao gerado.',
+          generatePost: 'Gerar POST',
+          generatingPost: 'Gerando post...',
+          generateSuccess: 'Post gerado com sucesso.',
+          generateReused: 'Post ja gerado anteriormente.',
           postUnavailable: 'Post ainda nao disponivel.',
           article: {
             readMore: 'Ver mais',

--- a/frontend/src/features/posts/api/posts.ts
+++ b/frontend/src/features/posts/api/posts.ts
@@ -1,6 +1,7 @@
 import {
   cleanupResultSchema,
   postGenerationProgressSchema,
+  postListItemSchema,
   postListMetaSchema,
   postListSchema,
   refreshSummarySchema,
@@ -73,6 +74,26 @@ const refreshProgressResponseSchema = z.object({
 export const fetchRefreshProgress = async (): Promise<PostGenerationProgress | null> => {
   const response = await getJson('/api/v1/posts/refresh-status', refreshProgressResponseSchema);
   return response.status ?? null;
+};
+
+const generatePostResponseSchema = z.object({
+  item: postListItemSchema,
+  cacheInfo: z
+    .object({
+      cachedTokens: z.number().int().nonnegative().nullable(),
+    })
+    .nullable(),
+  reused: z.boolean().optional(),
+});
+
+export type GeneratePostResponse = z.infer<typeof generatePostResponseSchema>;
+
+export const generatePost = ({ articleId }: { articleId: number }): Promise<GeneratePostResponse> => {
+  return postJson<GeneratePostResponse, Record<string, never>>(
+    `/api/v1/posts/${articleId}/generate`,
+    {},
+    generatePostResponseSchema,
+  );
 };
 
 type FetchPostRequestPreviewParams = {

--- a/frontend/src/features/posts/hooks/usePosts.ts
+++ b/frontend/src/features/posts/hooks/usePosts.ts
@@ -1,6 +1,14 @@
 import { keepPreviousData, useMutation, useQuery, type UseQueryResult } from '@tanstack/react-query';
 
-import { cleanupPosts, fetchPosts, refreshPosts, POSTS_QUERY_KEY, type PostListResponse } from '../api/posts';
+import {
+  cleanupPosts,
+  fetchPosts,
+  generatePost,
+  refreshPosts,
+  POSTS_QUERY_KEY,
+  type GeneratePostResponse,
+  type PostListResponse,
+} from '../api/posts';
 import type { CleanupResult, RefreshSummary } from '../types/post';
 import { HttpError } from '@/lib/api/http';
 import { useAuth } from '@/features/auth/hooks/useAuth';
@@ -41,5 +49,11 @@ export const useRefreshPosts = () => {
 export const useCleanupPosts = () => {
   return useMutation<CleanupResult, HttpError>({
     mutationFn: () => cleanupPosts(),
+  });
+};
+
+export const useGeneratePost = () => {
+  return useMutation<GeneratePostResponse, HttpError, { articleId: number }>({
+    mutationFn: ({ articleId }) => generatePost({ articleId }),
   });
 };


### PR DESCRIPTION
## Summary
- stop auto-generating posts during feed refresh and add a POST /api/v1/posts/{articleId}/generate endpoint
- expose the manual generation API to the frontend and wire a "Generate post" action with state updates
- refresh translations and tests to reflect manual generation behaviour

## Testing
- npm test -- posts.e2e.test.js
- npm test -- src/pages/posts/PostsPage.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e2934d272883258906ac32d899da43