### PR TITLE
Add CSV export option to feeds page

### DIFF
--- a/frontend/src/config/i18n.ts
+++ b/frontend/src/config/i18n.ts
@@ -194,6 +194,21 @@ const resources = {
             invalidUrl: 'Invalid URL format.',
           },
         },
+        export: {
+          action: 'Export CSV',
+          pending: 'Exporting...',
+          success: 'Export complete. {{count}} feeds exported.',
+          error: 'Could not export feeds. Try again.',
+          filename: 'feeds-{{timestamp}}.csv',
+          headers: {
+            id: 'ID',
+            title: 'Title',
+            url: 'URL',
+            lastFetchedAt: 'Last fetched at',
+            createdAt: 'Created at',
+            updatedAt: 'Updated at',
+          },
+        },
         errors: {
           duplicate: 'This feed is already registered.',
           invalidUrl: 'Enter a valid URL starting with http:// or https://.',
@@ -703,6 +718,21 @@ const resources = {
             duplicateInPayload: 'URL duplicada no envio em lote.',
             urlRequired: 'URL obrigatoria.',
             invalidUrl: 'Formato de URL invalido.',
+          },
+        },
+        export: {
+          action: 'Exportar CSV',
+          pending: 'Exportando...',
+          success: 'Exportação concluída. {{count}} feeds exportados.',
+          error: 'Não foi possível exportar os feeds. Tente novamente.',
+          filename: 'feeds-{{timestamp}}.csv',
+          headers: {
+            id: 'ID',
+            title: 'Título',
+            url: 'URL',
+            lastFetchedAt: 'Última coleta',
+            createdAt: 'Criado em',
+            updatedAt: 'Atualizado em',
           },
         },
         errors: {


### PR DESCRIPTION
## Summary
- add a CSV export flow for feeds, including a new handler and UI button
- provide localized strings for the export labels in English and Portuguese
- add tests that cover the CSV export behavior and verify generated output

## Testing
- npm run test -- src/pages/feeds/FeedsPage.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e30a90c9e883259a6ef6058e8bbc20