### PR TITLE
feat: add feed URL search filter

### DIFF
--- a/backend/src/controllers/feed.controller.js
+++ b/backend/src/controllers/feed.controller.js
@@ -23,12 +23,13 @@ const mapFeed = (feed) => ({
 
 const list = asyncHandler(async (req, res) => {
   const ownerKey = getOwnerKey(req);
-  const { cursor, limit } = req.validated?.query ?? {};
+  const { cursor, limit, search } = req.validated?.query ?? {};
 
   const { items, nextCursor, total, limit: appliedLimit } = await feedService.listFeeds({
     ownerKey,
     cursor,
     limit,
+    search,
   });
 
   res.withCache(30, 'private');

--- a/backend/src/repositories/feed.repository.js
+++ b/backend/src/repositories/feed.repository.js
@@ -1,8 +1,18 @@
 const { prisma } = require('../lib/prisma');
 
-const findPageByOwner = async ({ ownerKey, cursorId, take }) => {
+const buildOwnerWhereClause = ({ ownerKey, search }) => {
+  const where = { ownerKey };
+
+  if (search) {
+    where.url = { contains: search, mode: 'insensitive' };
+  }
+
+  return where;
+};
+
+const findPageByOwner = async ({ ownerKey, cursorId, take, search }) => {
   const query = {
-    where: { ownerKey },
+    where: buildOwnerWhereClause({ ownerKey, search }),
     orderBy: { id: 'asc' },
     take,
   };
@@ -15,7 +25,8 @@ const findPageByOwner = async ({ ownerKey, cursorId, take }) => {
   return prisma.feed.findMany(query);
 };
 
-const countByOwner = (ownerKey) => prisma.feed.count({ where: { ownerKey } });
+const countByOwner = ({ ownerKey, search }) =>
+  prisma.feed.count({ where: buildOwnerWhereClause({ ownerKey, search }) });
 
 const findById = (id) => prisma.feed.findUnique({ where: { id } });
 

--- a/backend/src/routes/v1/feed.routes.js
+++ b/backend/src/routes/v1/feed.routes.js
@@ -37,6 +37,11 @@ const router = express.Router();
  *           minimum: 1
  *           maximum: 50
  *         description: Quantidade máxima de feeds retornados por página (padrão 20, limite 50).
+ *       - in: query
+ *         name: search
+ *         schema:
+ *           type: string
+ *         description: Trecho da URL para filtrar os feeds cadastrados (busca parcial, sem diferenciar maiúsculas/minúsculas).
  *     responses:
  *       '200':
  *         description: Paginated list of feeds

--- a/backend/src/schemas/feed.schema.js
+++ b/backend/src/schemas/feed.schema.js
@@ -20,6 +20,7 @@ const listFeedsQuerySchema = z
   .object({
     cursor: positiveInt.optional(),
     limit: positiveInt.optional(),
+    search: z.string().optional(),
   })
   .strict();
 

--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -171,6 +171,25 @@ jest.mock('../src/lib/prisma', () => {
       return feed.url === urlCondition;
     }
 
+    if (typeof urlCondition === 'object' && urlCondition !== null) {
+      if (Object.hasOwn(urlCondition, 'not')) {
+        return !matchesUrlCondition(feed, urlCondition.not);
+      }
+
+      if (Object.hasOwn(urlCondition, 'equals')) {
+        return feed.url === urlCondition.equals;
+      }
+
+      if (typeof urlCondition.contains === 'string') {
+        const haystack = urlCondition.mode === 'insensitive' ? feed.url.toLowerCase() : feed.url;
+        const needle = urlCondition.mode === 'insensitive'
+          ? urlCondition.contains.toLowerCase()
+          : urlCondition.contains;
+
+        return haystack.includes(needle);
+      }
+    }
+
     return true;
   };
 

--- a/frontend/src/config/i18n.ts
+++ b/frontend/src/config/i18n.ts
@@ -224,6 +224,15 @@ const resources = {
             title: 'No feed registered yet.',
             description: 'Add your feeds individually or in bulk to start generating posts.',
           },
+          search: {
+            label: 'Filter by URL',
+            placeholder: 'Search feed URL',
+            submit: 'Search',
+            searching: 'Searching...',
+            clear: 'Clear',
+            noResults: 'No feeds found for this search.',
+            noResultsDescription: 'Try adjusting the filter or clear it to see all feeds.',
+          },
           headers: {
             feed: 'Feed',
             lastFetchedAt: 'Last update',
@@ -749,6 +758,15 @@ const resources = {
           empty: {
             title: 'Nenhum feed cadastrado ainda.',
             description: 'Adicione seus feeds individuais ou em lote para comecar a gerar posts.',
+          },
+          search: {
+            label: 'Filtrar por URL',
+            placeholder: 'Busque pela URL do feed',
+            submit: 'Buscar',
+            searching: 'Buscando...',
+            clear: 'Limpar',
+            noResults: 'Nenhum feed encontrado para esta busca.',
+            noResultsDescription: 'Ajuste o filtro ou limpe a busca para ver todos os feeds.',
           },
           headers: {
             feed: 'Feed',

--- a/frontend/src/features/feeds/api/feeds.ts
+++ b/frontend/src/features/feeds/api/feeds.ts
@@ -23,9 +23,10 @@ export type FeedListResponse = {
 type FetchFeedsParams = {
   cursor?: string | null;
   limit?: number;
+  search?: string | null;
 };
 
-const buildFeedsPath = ({ cursor, limit }: FetchFeedsParams = {}) => {
+const buildFeedsPath = ({ cursor, limit, search }: FetchFeedsParams = {}) => {
   const searchParams = new URLSearchParams();
 
   if (cursor) {
@@ -34,6 +35,14 @@ const buildFeedsPath = ({ cursor, limit }: FetchFeedsParams = {}) => {
 
   if (typeof limit === 'number') {
     searchParams.set('limit', String(limit));
+  }
+
+  if (typeof search === 'string') {
+    const trimmed = search.trim();
+
+    if (trimmed.length > 0) {
+      searchParams.set('search', trimmed);
+    }
   }
 
   const query = searchParams.toString();

--- a/frontend/src/pages/posts/PostsPage.tsx
+++ b/frontend/src/pages/posts/PostsPage.tsx
@@ -980,7 +980,7 @@ const PostsPage = () => {
     });
   }, []);
 
-  const feedList = useFeedList({ cursor: null, limit: FEED_OPTIONS_LIMIT });
+  const feedList = useFeedList({ cursor: null, limit: FEED_OPTIONS_LIMIT, search: null });
   const feedListData = feedList.data;
   const feeds: Feed[] = feedListData?.items ?? [];
   const totalFeeds: number = feedListData?.meta.total ?? 0;


### PR DESCRIPTION
## Summary
- allow the feed list endpoint to accept an optional search term and filter URLs case-insensitively
- expose a feed URL search box in the Feeds page with localized copy and tailored empty state messaging
- cover the new search flow with backend and frontend tests and adjust shared feed queries to include the filter

## Testing
- npm test -- feeds.e2e.test.js
- npm test -- FeedsPage.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e314449ef4832591be802bcc5b0f93