### PR TITLE
Prevent deleted feeds from reappearing immediately

### DIFF
--- a/frontend/src/features/feeds/hooks/useFeeds.ts
+++ b/frontend/src/features/feeds/hooks/useFeeds.ts
@@ -215,7 +215,10 @@ export const useDeleteFeed = () => {
           },
         };
       });
-      queryClient.invalidateQueries({ queryKey: FEEDS_QUERY_KEY }).catch(() => {
+      queryClient.invalidateQueries({
+        queryKey: FEEDS_QUERY_KEY,
+        refetchType: 'inactive',
+      }).catch(() => {
         // ignore cache errors
       });
     },

--- a/frontend/src/pages/feeds/FeedsPage.test.tsx
+++ b/frontend/src/pages/feeds/FeedsPage.test.tsx
@@ -588,9 +588,7 @@ describe('FeedsPage', () => {
 
     expect(deleteMutate).toHaveBeenCalledWith(1, expect.any(Object));
     expect(screen.getByText('Feed removido com sucesso.')).toBeInTheDocument();
-    await waitFor(() => {
-      expect(feedListQueryResult.refetch).toHaveBeenCalledTimes(1);
-    });
+    expect(feedListQueryResult.refetch).not.toHaveBeenCalled();
   });
 
   it('does not render the reset button for non-admin users', () => {

--- a/frontend/src/pages/feeds/FeedsPage.tsx
+++ b/frontend/src/pages/feeds/FeedsPage.tsx
@@ -468,7 +468,6 @@ const FeedsPage = () => {
         if (editingFeed?.id === targetFeed.id) {
           handleCancelEdit();
         }
-        resetPagination();
       },
       onError: (error) => {
         const message = resolveErrorMessage(error);


### PR DESCRIPTION
## Summary
- stop forcing a pagination reset/refetch after confirming a feed deletion so the optimistic cache removal persists
- invalidate the feeds query without refetching active queries to avoid reloading stale server data immediately after a deletion
- update the feeds page test to reflect the new behavior

## Testing
- npm test -- FeedsPage

------
https://chatgpt.com/codex/tasks/task_e_68e401da2398832590b6ef072deec920