### PR TITLE
Add custom prompt support for manual post generation

### DIFF
--- a/backend/src/controllers/posts.controller.js
+++ b/backend/src/controllers/posts.controller.js
@@ -95,6 +95,7 @@ const refresh = asyncHandler(async (req, res) => {
 const generateForArticle = asyncHandler(async (req, res) => {
   const ownerKey = getOwnerKey(req);
   const articleIdParam = req.params?.articleId;
+  const customPrompt = typeof req.body?.customPrompt === 'string' ? req.body.customPrompt : undefined;
 
   const articleId = Number.parseInt(articleIdParam, 10);
   if (!Number.isInteger(articleId) || articleId <= 0) {
@@ -106,7 +107,7 @@ const generateForArticle = asyncHandler(async (req, res) => {
   }
 
   try {
-    const result = await postGenerationService.generatePostForArticleId({ ownerKey, articleId });
+    const result = await postGenerationService.generatePostForArticleId({ ownerKey, articleId, customPrompt });
     const includeDiagnostics = !config.isProduction || req.user?.role === ROLES.ADMIN;
     const item = mapPostListItem(result.article, { includeDiagnostics });
 

--- a/backend/src/routes/v1/posts.routes.js
+++ b/backend/src/routes/v1/posts.routes.js
@@ -86,6 +86,16 @@ router.post('/posts/refresh', postsController.refresh);
  *         schema:
  *           type: integer
  *           minimum: 1
+ *     requestBody:
+ *       required: false
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               customPrompt:
+ *                 type: string
+ *                 description: Instrução adicional opcional concatenada antes da notícia ao gerar o post.
  *     responses:
  *       '200':
  *         description: Post gerado com sucesso

--- a/frontend/src/features/posts/api/posts.ts
+++ b/frontend/src/features/posts/api/posts.ts
@@ -77,10 +77,26 @@ const generatePostResponseSchema = z.object({
 
 export type GeneratePostResponse = z.infer<typeof generatePostResponseSchema>;
 
-export const generatePost = ({ articleId }: { articleId: number }): Promise<GeneratePostResponse> => {
-  return postJson<GeneratePostResponse, Record<string, never>>(
+type GeneratePostRequestPayload = {
+  customPrompt?: string;
+};
+
+export const generatePost = ({
+  articleId,
+  customPrompt,
+}: {
+  articleId: number;
+  customPrompt?: string;
+}): Promise<GeneratePostResponse> => {
+  const payload: GeneratePostRequestPayload = {};
+
+  if (typeof customPrompt === 'string' && customPrompt.trim().length > 0) {
+    payload.customPrompt = customPrompt;
+  }
+
+  return postJson<GeneratePostResponse, GeneratePostRequestPayload>(
     `/api/v1/posts/${articleId}/generate`,
-    {},
+    payload,
     generatePostResponseSchema,
   );
 };

--- a/frontend/src/features/posts/hooks/usePosts.ts
+++ b/frontend/src/features/posts/hooks/usePosts.ts
@@ -53,7 +53,11 @@ export const useCleanupPosts = () => {
 };
 
 export const useGeneratePost = () => {
-  return useMutation<GeneratePostResponse, HttpError, { articleId: number }>({
-    mutationFn: ({ articleId }) => generatePost({ articleId }),
+  return useMutation<
+    GeneratePostResponse,
+    HttpError,
+    { articleId: number; customPrompt?: string }
+  >({
+    mutationFn: ({ articleId, customPrompt }) => generatePost({ articleId, customPrompt }),
   });
 };


### PR DESCRIPTION
## Summary
- add an optional custom prompt textarea to the manual generation UI and include it in requests
- extend the backend generation flow to accept the custom prompt and recompute prompt hashes
- cover the new behaviour with updated frontend and backend tests

## Testing
- npm test -- PostsPage.test.tsx
- npm test -- tests/posts.e2e.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e4072f463483259808a16d2b3caf78