### PR TITLE
Implement automatic scroll to top on posts pagination

### DIFF
--- a/frontend/src/pages/posts/PostsPage.tsx
+++ b/frontend/src/pages/posts/PostsPage.tsx
@@ -2902,6 +2902,40 @@ const PostListContent = ({
   feedListIsSuccess,
   formattedTimeWindowDays,
 }: PostListContentProps): JSX.Element => {
+    const scrollAnchorRef = useRef<HTMLDivElement | null>(null);
+    const previousPageRef = useRef<number>(currentPage);
+    const shouldScrollToTopRef = useRef(false);
+
+    useEffect(() => {
+      if (previousPageRef.current !== currentPage) {
+        previousPageRef.current = currentPage;
+        shouldScrollToTopRef.current = true;
+      }
+    }, [currentPage]);
+
+    useEffect(() => {
+      if (!shouldScrollToTopRef.current) {
+        return;
+      }
+
+      if (typeof window === 'undefined') {
+        return;
+      }
+
+      if (isLoading || posts.length === 0) {
+        return;
+      }
+
+      const anchor = scrollAnchorRef.current;
+
+      if (!anchor) {
+        return;
+      }
+
+      shouldScrollToTopRef.current = false;
+      anchor.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }, [isLoading, posts]);
+
     const fallback = renderListFallbackContent({
       hasExecutedSequence,
       feedListIsSuccess,
@@ -2924,6 +2958,7 @@ const PostListContent = ({
 
     return (
       <div className="space-y-4">
+        <div ref={scrollAnchorRef} aria-hidden="true" />
         {posts.map((item) => {
           const sectionState = expandedSections[item.id] ?? createDefaultSectionState();
           const postContentId = `post-content-${item.id}`;


### PR DESCRIPTION
## Summary
- add a scroll anchor to the posts list and track page changes
- trigger a smooth scroll to the top of the list once the next page has loaded

## Testing
- npm run test -- PostsPage

------
https://chatgpt.com/codex/tasks/task_e_68e855be8ad883259e53106a36c659ce